### PR TITLE
feat: add schemaAuthToken for authenticated schema introspection

### DIFF
--- a/docs/content/1.getting-started/3.wordpress-setup.md
+++ b/docs/content/1.getting-started/3.wordpress-setup.md
@@ -28,7 +28,10 @@ In **WordPress Admin → GraphQL → Settings**, configure:
 | Public Introspection | Yes | Required during development so WPNuxt can download the schema without authentication |
 
 ::callout{type="warning"}
-Disable **Public Introspection** in production if your schema contains sensitive information. In that case, set `downloadSchema: false` and commit `schema.graphql` to your repository.
+Disable **Public Introspection** in production if your schema contains sensitive information. You have two options:
+
+1. **Recommended:** Set `schemaAuthToken` (or the `WPNUXT_SCHEMA_AUTH_TOKEN` env var) to a WPGraphQL authentication token. WPNuxt sends this as a Bearer token during build-time schema operations, so introspection works without being publicly exposed. See [Securing Introspection](#securing-introspection) below.
+2. Set `downloadSchema: false` and commit `schema.graphql` to your repository. You must manually update the schema file whenever your WordPress schema changes.
 ::
 
 ::callout{type="info"}
@@ -67,6 +70,37 @@ After installation, configure providers in **WordPress Admin → GraphQL → Hea
 2. Optionally configure OAuth providers (Google, GitHub, etc.) for social login
 
 See the [Authentication Guide](/auth) for detailed setup instructions.
+
+## Securing Introspection
+
+By default, WPGraphQL exposes the schema publicly. This is fine during development, but in production you may want to disable **Public Introspection** to hide your schema from unauthenticated users.
+
+WPNuxt supports authenticated schema introspection via the `schemaAuthToken` option. When configured, WPNuxt sends the token as a `Bearer` header during build-time operations (endpoint validation and schema download), allowing introspection to work without public access.
+
+### Setup
+
+1. In WordPress Admin, go to **GraphQL → Settings**
+2. Keep **Enable Introspection** set to **Yes**
+3. Set **Public Introspection** to **No**
+4. Generate an application password or authentication token for a WordPress user with sufficient permissions
+5. Add the token to your environment:
+
+```bash [.env]
+WPNUXT_SCHEMA_AUTH_TOKEN=your-auth-token
+```
+
+Or set it directly in `nuxt.config.ts`:
+
+```ts [nuxt.config.ts]
+wpNuxt: {
+  wordpressUrl: 'https://wordpress.example.com',
+  schemaAuthToken: process.env.WPNUXT_SCHEMA_AUTH_TOKEN
+}
+```
+
+::callout{type="info"}
+The `schemaAuthToken` is only used at build time for schema operations. It is never included in client bundles or runtime requests. For runtime authentication, use `@wpnuxt/auth`.
+::
 
 ## Verify Your Setup
 

--- a/docs/content/5.reference/1.configuration.md
+++ b/docs/content/5.reference/1.configuration.md
@@ -22,11 +22,14 @@ export default defineNuxtConfig({
 | `wordpressUrl` | `string` | — | **Required.** WordPress URL (no trailing slash) |
 | `graphqlEndpoint` | `string` | `'/graphql'` | GraphQL endpoint path |
 | `downloadSchema` | `boolean` | `true` | Download schema on build |
+| `schemaAuthToken` | `string` | — | Bearer token for authenticated schema introspection |
 | `debug` | `boolean` | `false` | Enable debug logging |
 
 **`downloadSchema`** — WPNuxt downloads your WordPress GraphQL schema at build time to generate TypeScript types and validate queries. Set to `false` only if you commit `schema.graphql` to version control and update it manually. If `false` and no schema file exists, the build fails.
 
 **`debug`** — Logs query merging, endpoint validation, module load times, and cache config to the server console. No production performance impact. Useful when composables aren't being generated or the WordPress connection fails.
+
+**`schemaAuthToken`** — A Bearer token sent with build-time requests to your WordPress GraphQL endpoint: the introspection check and the schema download. Required when **Public Introspection** is disabled in WPGraphQL. The token is only used at build time and is never included in client bundles. Can also be set via the `WPNUXT_SCHEMA_AUTH_TOKEN` environment variable (recommended for CI/CD). See [WordPress Setup](/getting-started/wordpress-setup#securing-introspection) for details.
 
 **`graphqlEndpoint`** — Only change this if a security plugin renames your WordPress GraphQL endpoint to something other than `/graphql`.
 
@@ -214,6 +217,7 @@ wpNuxtAuth: {
 | `WPNUXT_WORDPRESS_URL` | `wordpressUrl` |
 | `WPNUXT_GRAPHQL_ENDPOINT` | `graphqlEndpoint` |
 | `WPNUXT_DOWNLOAD_SCHEMA` | `downloadSchema` |
+| `WPNUXT_SCHEMA_AUTH_TOKEN` | `schemaAuthToken` |
 | `WPNUXT_DEBUG` | `debug` |
 
 ### @wpnuxt/auth
@@ -228,6 +232,9 @@ Environment variables take precedence over `nuxt.config.ts`.
 ```bash [.env]
 WPNUXT_WORDPRESS_URL=https://wordpress.example.com
 WPNUXT_DEBUG=true
+
+# For authenticated schema introspection (when public introspection is disabled)
+WPNUXT_SCHEMA_AUTH_TOKEN=your-wpgraphql-token
 
 # For OAuth (miniOrange)
 WPNUXT_OAUTH_CLIENT_ID=your-client-id

--- a/docs/content/5.reference/3.troubleshooting.md
+++ b/docs/content/5.reference/3.troubleshooting.md
@@ -129,6 +129,34 @@ The schema file does not exist or is empty. Run 'pnpm dev:prepare' first.
 
 ## Build Errors
 
+### Schema download failed (403 / introspection disabled)
+
+```
+[WPNuxt] WordPress GraphQL endpoint returned HTTP 403.
+```
+
+or
+
+```
+[WPNuxt] Failed to download GraphQL schema.
+```
+
+**Cause:** Public introspection is disabled on your WordPress GraphQL endpoint. WPNuxt needs introspection access at build time to download the schema and generate types.
+
+**Solution:**
+
+Set the `WPNUXT_SCHEMA_AUTH_TOKEN` environment variable to a valid authentication token:
+
+```bash [.env]
+WPNUXT_SCHEMA_AUTH_TOKEN=your-auth-token
+```
+
+This sends the token as a `Bearer` header during build-time schema operations. See [Securing Introspection](/getting-started/wordpress-setup#securing-introspection) for setup details.
+
+Alternatively, set `downloadSchema: false` and commit a manually-downloaded `schema.graphql` to your repository.
+
+---
+
 ### GraphQL document validation failed
 
 ```

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -51,6 +51,20 @@ export interface WPNuxtConfig {
   downloadSchema: boolean
 
   /**
+   * Bearer token for authenticated schema introspection at build time.
+   *
+   * Required when your WordPress GraphQL endpoint has public introspection disabled.
+   * The token is sent as an `Authorization: Bearer <token>` header during:
+   * - Endpoint validation (introspection query)
+   * - Schema download (get-graphql-schema)
+   *
+   * Can also be set via `WPNUXT_SCHEMA_AUTH_TOKEN` environment variable.
+   *
+   * This token is only used at build time and is NOT included in client bundles.
+   */
+  schemaAuthToken?: string
+
+  /**
    * Whether to enable debug mode
    *
    * @default false


### PR DESCRIPTION
When WordPress GraphQL endpoints have public introspection disabled,
WPNuxt fails at dev:prepare because schema operations send no auth
headers. Add a schemaAuthToken config option (and WPNUXT_SCHEMA_AUTH_TOKEN
env var) that provides a Bearer token for build-time schema operations:
endpoint validation, schema download, and nuxt-graphql-middleware codegen.

Closes #37