### PR TITLE
feat: enhance Posts queries with ordering options

### DIFF
--- a/packages/core/src/runtime/composables/useWPContent.ts
+++ b/packages/core/src/runtime/composables/useWPContent.ts
@@ -65,8 +65,9 @@ const defaultGetCachedData = (key: string, app: NuxtApp, ctx: AsyncDataRequestCo
   if (app.isHydrating) {
     return app.payload.data[key]
   }
-  // For refresh actions, don't use cache (same as nuxt-graphql-middleware behavior)
-  if (ctx.cause === 'refresh:manual' || ctx.cause === 'refresh:hook') {
+  // For refresh or watch-triggered re-fetches, don't use cache
+  // Watch means reactive params changed, so we need fresh data with the new variables
+  if (ctx.cause === 'refresh:manual' || ctx.cause === 'refresh:hook' || ctx.cause === 'watch') {
     return undefined
   }
   // For SSG client navigation, check static.data (prerendered payloads)

--- a/packages/core/src/runtime/queries/Posts.gql
+++ b/packages/core/src/runtime/queries/Posts.gql
@@ -1,5 +1,5 @@
-query Posts($limit: Int = 10) {
-  posts(first: $limit) {
+query Posts($limit: Int = 10, $order: OrderEnum = DESC, $orderField: PostObjectsConnectionOrderbyEnum = DATE) {
+  posts(first: $limit, where: { orderby: { field: $orderField, order: $order } }) {
     nodes {
       ...Post
     }
@@ -16,15 +16,15 @@ query PostById($id: ID!, $asPreview: Boolean = false) {
   }
 }
 
-query PostsByCategoryName($categoryName: String!, $limit: Int = 10) {
-  posts(first: $limit, where: {categoryName: $categoryName}) {
+query PostsByCategoryName($categoryName: String!, $limit: Int = 10, $order: OrderEnum = DESC, $orderField: PostObjectsConnectionOrderbyEnum = DATE) {
+  posts(first: $limit, where: {categoryName: $categoryName, orderby: { field: $orderField, order: $order }}) {
     nodes {
       ...Post
     }
   }
 }
-query PostsByCategoryId($categoryId: Int!, $limit: Int = 10) {
-  posts(first: $limit, where: {categoryId: $categoryId}) {
+query PostsByCategoryId($categoryId: Int!, $limit: Int = 10, $order: OrderEnum = DESC, $orderField: PostObjectsConnectionOrderbyEnum = DATE) {
+  posts(first: $limit, where: {categoryId: $categoryId, orderby: { field: $orderField, order: $order }}) {
     nodes {
       ...Post
     }

--- a/playgrounds/full/app/pages/index.vue
+++ b/playgrounds/full/app/pages/index.vue
@@ -1,5 +1,14 @@
 <script setup lang="ts">
-const { data: posts, pending, refresh, clear } = await usePosts()
+const orderField = ref('DATE')
+const order = ref('DESC')
+
+const orderFieldOptions = ['DATE', 'TITLE', 'MODIFIED', 'AUTHOR', 'COMMENT_COUNT']
+const orderOptions = ['DESC', 'ASC']
+
+const { data: posts, pending, refresh, clear } = await usePosts(() => ({
+  orderField: orderField.value,
+  order: order.value
+}))
 </script>
 
 <template>
@@ -10,9 +19,17 @@ const { data: posts, pending, refresh, clear } = await usePosts()
         :pending="pending"
         :refresh-content="() => { clear(); refresh(); }"
         composable-name="usePosts"
-        composable-script="const { data: posts, pending, refresh, clear } = await usePosts()"
+        composable-script="const { data: posts, pending, refresh, clear } = await usePosts(() => ({ orderField: orderField.value, order: order.value }))"
       />
       <UPageBody>
+        <div class="flex justify-end gap-4 mb-6">
+          <UFormField label="Order by">
+            <USelect v-model="orderField" :items="orderFieldOptions" />
+          </UFormField>
+          <UFormField label="Direction">
+            <USelect v-model="order" :items="orderOptions" />
+          </UFormField>
+        </div>
         <UBlogPosts>
           <UBlogPost
             v-for="post in posts"


### PR DESCRIPTION
- Updated GraphQL queries for Posts to include ordering parameters (orderField and order).
- Modified the playground's index.vue to allow users to select order criteria and direction via dropdowns.
- Adjusted the usePosts composable to accept new ordering options for improved data fetching.