### PR TITLE
docs: note Twenty Twenty-One is the last classic default theme

### DIFF
--- a/docs/content/2.guide/8.menus.md
+++ b/docs/content/2.guide/8.menus.md
@@ -86,7 +86,7 @@ If you're using a block theme and don't see **Appearance → Menus**:
 3. The menu data persists regardless of active theme
 
 ::callout{type="info"}
-**Which default themes are classic?** The last default WordPress theme built as a classic (non-FSE) theme is **Twenty Twenty-One**. Twenty Twenty-Two through Twenty Twenty-Five are block themes. If you want a bundled classic theme for menu editing, install Twenty Twenty-One.
+**Which default themes are classic?** The last default WordPress theme built as a classic (non-FSE) theme is **Twenty Twenty-One**. Twenty Twenty-Two through Twenty Twenty-Five are block themes. If you want an official classic theme for menu editing, install Twenty Twenty-One.
 ::
 
 ::callout{type="info"}

--- a/docs/content/2.guide/8.menus.md
+++ b/docs/content/2.guide/8.menus.md
@@ -86,6 +86,10 @@ If you're using a block theme and don't see **Appearance → Menus**:
 3. The menu data persists regardless of active theme
 
 ::callout{type="info"}
+**Which default themes are classic?** The last default WordPress theme built as a classic (non-FSE) theme is **Twenty Twenty-One**. Twenty Twenty-Two through Twenty Twenty-Five are block themes. If you want a bundled classic theme for menu editing, install Twenty Twenty-One.
+::
+
+::callout{type="info"}
 The menu name in WordPress must match what you pass to `useMenu()`. By default, WPNuxt looks for a menu named `"main"`.
 ::
 

--- a/docs/content/2.guide/8.menus.md
+++ b/docs/content/2.guide/8.menus.md
@@ -86,7 +86,7 @@ If you're using a block theme and don't see **Appearance → Menus**:
 3. The menu data persists regardless of active theme
 
 ::callout{type="info"}
-**Which default themes are classic?** The last default WordPress theme built as a classic (non-FSE) theme is **Twenty Twenty-One**. Twenty Twenty-Two through Twenty Twenty-Five are block themes. If you want an official classic theme for menu editing, install Twenty Twenty-One.
+**Which default themes are classic?** The last default WordPress theme built as a classic (non-FSE) theme is **Twenty Twenty-One**. Later default themes, starting with **Twenty Twenty-Two**, are block themes. If you want an official classic theme for menu editing, install Twenty Twenty-One.
 ::
 
 ::callout{type="info"}


### PR DESCRIPTION
## Summary

Adds a small callout to the Menus guide clarifying which bundled WordPress themes still ship as classic (non-FSE) themes. The existing docs tell block-theme users they can "install a classic theme temporarily," but don't say which one — **Twenty Twenty-One** is the last default classic theme; Twenty Twenty-Two through Twenty Twenty-Five are all block themes.

Came up while onboarding a new project and hitting the `Menu not found` warning from `useMenu({ name: 'main' })` on a fresh WordPress install running a block theme.

## Test plan

- [ ] Preview the `/guide/menus` page and confirm the callout renders correctly