### PR TITLE
refactor(core): introduce internal GraphQL client wrapper

### DIFF
--- a/packages/core/src/generate.ts
+++ b/packages/core/src/generate.ts
@@ -161,7 +161,7 @@ export async function prepareContext(ctx: WPNuxtContext) {
     const functionName = mutationFnName(m.name)
 
     if (!typed) {
-      return `export const ${functionName} = (variables, options) => useGraphqlMutation('${m.name}', variables, options)`
+      return `export const ${functionName} = (variables, options) => wpMutation('${m.name}', variables, options)`
     }
     return `  export const ${functionName}: (variables: ${m.name}MutationVariables, options?: WPMutationOptions) => Promise<WPMutationResult<${m.name}Mutation>>`
   }
@@ -180,11 +180,15 @@ export async function prepareContext(ctx: WPNuxtContext) {
     if (hasConnectionQueries) {
       imports.push('useWPConnection')
     }
-    if (mutations.length > 0) {
-      imports.push('useGraphqlMutation')
-    }
     if (imports.length > 0) {
       lines.push(`import { ${imports.join(', ')} } from '#imports'`)
+    }
+    // Mutations route through the internal client wrapper so future changes to
+    // nuxt-graphql-middleware are absorbed in one file rather than every call site.
+    if (mutations.length > 0) {
+      lines.push(`import { wpMutation } from '#wpnuxt-internal'`)
+    }
+    if (lines.length > 0) {
       lines.push('')
     }
 

--- a/packages/core/src/module.ts
+++ b/packages/core/src/module.ts
@@ -271,6 +271,7 @@ export default defineNuxtModule<WPNuxtConfig>({
     nuxt.options.alias['#wpnuxt'] = resolver.resolve(nuxt.options.buildDir, 'wpnuxt')
     nuxt.options.alias['#wpnuxt/*'] = resolver.resolve(nuxt.options.buildDir, 'wpnuxt', '*')
     nuxt.options.alias['#wpnuxt/types'] = resolver.resolve('./types')
+    nuxt.options.alias['#wpnuxt-internal'] = resolver.resolve('./runtime/internal/graphql-client')
 
     // Alias @wpnuxt/core subpath exports to source files during development.
     // Without this, imports like '@wpnuxt/core/server-options' resolve to
@@ -284,6 +285,7 @@ export default defineNuxtModule<WPNuxtConfig>({
     nitroOpts.nitro = nitroOpts.nitro || {}
     nitroOpts.nitro.alias = nitroOpts.nitro.alias || {}
     nitroOpts.nitro.alias['#wpnuxt/types'] = resolver.resolve('./types')
+    nitroOpts.nitro.alias['#wpnuxt-internal'] = resolver.resolve('./runtime/internal/graphql-client')
 
     nitroOpts.nitro.externals = nitroOpts.nitro.externals || {}
     nitroOpts.nitro.externals.inline = nitroOpts.nitro.externals.inline || []

--- a/packages/core/src/runtime/composables/useWPContent.ts
+++ b/packages/core/src/runtime/composables/useWPContent.ts
@@ -2,7 +2,8 @@ import { transformData, normalizeUriParam } from '../util/content'
 import type { Query } from '#nuxt-graphql-middleware/operation-types'
 import type { MaybeRefOrGetter, WatchSource, Ref } from 'vue'
 import type { NuxtApp } from 'nuxt/app'
-import { computed, ref, toValue, watch as vueWatch, useAsyncGraphqlQuery, useRuntimeConfig } from '#imports'
+import { computed, ref, toValue, watch as vueWatch, useRuntimeConfig } from '#imports'
+import { wpQuery } from '../internal/graphql-client'
 
 /** Extended NuxtApp with nuxt-graphql-middleware internals */
 interface NuxtAppWithGraphqlCache extends NuxtApp {
@@ -202,10 +203,11 @@ export const useWPContent = <T>(
     })
   }
 
-  // Use useAsyncGraphqlQuery with our custom getCachedData for SSG support
-  // Our getCachedData takes precedence over the built-in one
-  // Keep the full result (which is a thenable) so we can preserve await behavior
-  const asyncResult = useAsyncGraphqlQuery(
+  // Use wpQuery (internal wrapper around useAsyncGraphqlQuery) with our custom
+  // getCachedData for SSG support. Our getCachedData takes precedence over the
+  // built-in one. Keep the full result (which is a thenable) so we can preserve
+  // await behavior.
+  const asyncResult = wpQuery(
     String(queryName) as keyof Query,
     resolvedParams,
     asyncDataOptions

--- a/packages/core/src/runtime/internal/graphql-client.ts
+++ b/packages/core/src/runtime/internal/graphql-client.ts
@@ -1,0 +1,17 @@
+import { useAsyncGraphqlQuery, useGraphqlMutation } from '#imports'
+
+/**
+ * Internal GraphQL client surface for @wpnuxt/core.
+ *
+ * Centralizes the integration with nuxt-graphql-middleware so future upstream
+ * changes can be absorbed in this single file rather than every call site.
+ * Today these are direct re-exports; runtime instrumentation (e.g. telemetry
+ * hooks) will be layered here.
+ *
+ * Not part of the public API — exposed via the `#wpnuxt-internal` alias only
+ * for use by generated mutation composables. Consumers should keep using
+ * `useWPContent`, `useWPConnection`, the generated query composables, or call
+ * `useGraphqlMutation` directly (auto-imported via nuxt-graphql-middleware).
+ */
+export const wpQuery = useAsyncGraphqlQuery
+export const wpMutation = useGraphqlMutation

--- a/packages/core/src/runtime/types/stub.d.ts
+++ b/packages/core/src/runtime/types/stub.d.ts
@@ -42,6 +42,11 @@ export function useAsyncGraphqlQuery<T = unknown>(
   status: Ref<string>
 }
 export function useGraphqlState(): Record<string, unknown>
+export function useGraphqlMutation<T = unknown>(
+  name: string,
+  variables?: Record<string, unknown>,
+  options?: Record<string, unknown>
+): Promise<{ data: T | null, errors?: Array<{ message: string }> | null }>
 
 // Stub for #nuxt-graphql-middleware/operation-types
 export type Query = Record<string, unknown>

--- a/packages/core/test/generate.test.ts
+++ b/packages/core/test/generate.test.ts
@@ -57,7 +57,8 @@ describe('generate', () => {
       const imports = ctx.generateImports!()
 
       expect(imports).toContain('useMutationLogin')
-      expect(imports).toContain('useGraphqlMutation(\'Login\'')
+      expect(imports).toContain('wpMutation(\'Login\'')
+      expect(imports).toContain(`import { wpMutation } from '#wpnuxt-internal'`)
     })
 
     it('should generate type declarations', async () => {

--- a/packages/core/test/internal/graphql-client.test.ts
+++ b/packages/core/test/internal/graphql-client.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockUseAsyncGraphqlQuery = vi.fn()
+const mockUseGraphqlMutation = vi.fn()
+
+vi.mock('#imports', () => ({
+  useAsyncGraphqlQuery: mockUseAsyncGraphqlQuery,
+  useGraphqlMutation: mockUseGraphqlMutation
+}))
+
+describe('internal/graphql-client', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    mockUseAsyncGraphqlQuery.mockReset()
+    mockUseGraphqlMutation.mockReset()
+  })
+
+  it('wpQuery forwards arguments to useAsyncGraphqlQuery and returns its result', async () => {
+    const sentinelResult = { data: { value: { posts: { nodes: [] } } } }
+    mockUseAsyncGraphqlQuery.mockReturnValue(sentinelResult)
+
+    const { wpQuery } = await import('../../src/runtime/internal/graphql-client')
+    const params = { uri: '/hello-world/' }
+    const options = { lazy: true }
+    const result = wpQuery('Posts' as never, params as never, options as never)
+
+    expect(mockUseAsyncGraphqlQuery).toHaveBeenCalledTimes(1)
+    expect(mockUseAsyncGraphqlQuery).toHaveBeenCalledWith('Posts', params, options)
+    expect(result).toBe(sentinelResult)
+  })
+
+  it('wpMutation forwards arguments to useGraphqlMutation and returns its result', async () => {
+    const sentinelResult = Promise.resolve({ data: { login: { authToken: 'x' } } })
+    mockUseGraphqlMutation.mockReturnValue(sentinelResult)
+
+    const { wpMutation } = await import('../../src/runtime/internal/graphql-client')
+    const variables = { username: 'a', password: 'b' }
+    const options = { fetchOptions: { headers: { 'X-Test': '1' } } }
+    const result = wpMutation('Login' as never, variables as never, options as never)
+
+    expect(mockUseGraphqlMutation).toHaveBeenCalledTimes(1)
+    expect(mockUseGraphqlMutation).toHaveBeenCalledWith('Login', variables, options)
+    expect(result).toBe(sentinelResult)
+  })
+
+  it('wpQuery preserves thenable behavior of the underlying result', async () => {
+    const refs = { data: { value: { posts: { nodes: [{ id: 1 }] } } } }
+    const thenable = Object.assign(Promise.resolve(refs), refs)
+    mockUseAsyncGraphqlQuery.mockReturnValue(thenable)
+
+    const { wpQuery } = await import('../../src/runtime/internal/graphql-client')
+    const result = wpQuery('Posts' as never, {} as never, {} as never)
+
+    expect(result).toBe(thenable)
+    await expect(Promise.resolve(result)).resolves.toBe(refs)
+  })
+})

--- a/packages/core/test/usePrevNextPost.test.ts
+++ b/packages/core/test/usePrevNextPost.test.ts
@@ -7,6 +7,7 @@ vi.mock('#imports', () => ({
   toValue: vi.fn(val => val),
   watch: vi.fn(),
   useAsyncGraphqlQuery: vi.fn(),
+  useGraphqlMutation: vi.fn(),
   useRuntimeConfig: vi.fn(() => ({ public: { wpNuxt: {} } }))
 }))
 
@@ -56,6 +57,7 @@ describe('usePrevNextPost', () => {
       toValue: vi.fn(val => val),
       watch: vi.fn(),
       useAsyncGraphqlQuery: mockUseAsyncGraphqlQuery,
+      useGraphqlMutation: vi.fn(),
       useRuntimeConfig: vi.fn(() => ({ public: { wpNuxt: {} } }))
     }))
   })
@@ -124,6 +126,7 @@ describe('usePrevNextPost', () => {
       toValue: vi.fn(val => val),
       watch: vi.fn(),
       useAsyncGraphqlQuery: mockUseAsyncGraphqlQuery,
+      useGraphqlMutation: vi.fn(),
       useRuntimeConfig: vi.fn(() => ({ public: { wpNuxt: {} } }))
     }))
 

--- a/packages/core/test/useWPConnection.test.ts
+++ b/packages/core/test/useWPConnection.test.ts
@@ -8,6 +8,7 @@ vi.mock('#imports', () => ({
   toValue: vi.fn(val => val),
   watch: vi.fn(),
   useAsyncGraphqlQuery: vi.fn(),
+  useGraphqlMutation: vi.fn(),
   useRuntimeConfig: vi.fn(() => ({ public: { wpNuxt: {} } }))
 }))
 
@@ -69,6 +70,7 @@ describe('useWPConnection', () => {
       toValue: vi.fn(val => val),
       watch: vi.fn(),
       useAsyncGraphqlQuery: mockUseAsyncGraphqlQuery,
+      useGraphqlMutation: vi.fn(),
       useRuntimeConfig: vi.fn(() => ({ public: { wpNuxt: {} } }))
     }))
   })
@@ -126,6 +128,7 @@ describe('useWPConnection', () => {
       toValue: vi.fn(val => val),
       watch: vi.fn(),
       useAsyncGraphqlQuery: mockUseAsyncGraphqlQuery,
+      useGraphqlMutation: vi.fn(),
       useRuntimeConfig: vi.fn(() => ({ public: { wpNuxt: {} } }))
     }))
 
@@ -161,6 +164,7 @@ describe('useWPConnection', () => {
       toValue: vi.fn(val => val),
       watch: vi.fn(),
       useAsyncGraphqlQuery: mockUseAsyncGraphqlQuery,
+      useGraphqlMutation: vi.fn(),
       useRuntimeConfig: vi.fn(() => ({ public: { wpNuxt: {} } }))
     }))
 

--- a/packages/core/test/useWPContent.test.ts
+++ b/packages/core/test/useWPContent.test.ts
@@ -17,6 +17,7 @@ vi.mock('#imports', () => ({
   ref: vi.fn(val => ({ value: val })),
   watch: vi.fn(),
   useAsyncGraphqlQuery: vi.fn(),
+  useGraphqlMutation: vi.fn(),
   useRuntimeConfig: vi.fn(() => ({ public: { wpNuxt: {} } }))
 }))
 
@@ -74,6 +75,7 @@ describe('useWPContent', () => {
       ref: mockRef,
       watch: mockWatch,
       useAsyncGraphqlQuery: mockUseAsyncGraphqlQuery,
+      useGraphqlMutation: vi.fn(),
       useRuntimeConfig: vi.fn(() => ({ public: { wpNuxt: {} } }))
     }))
   })


### PR DESCRIPTION
Closes #262.

## Summary

- New `packages/core/src/runtime/internal/graphql-client.ts` exporting `wpQuery` and `wpMutation`. Today these are direct re-exports of `useAsyncGraphqlQuery` and `useGraphqlMutation` — the value is the indirection point.
- `useWPContent` now calls `wpQuery` instead of importing `useAsyncGraphqlQuery` from `#imports`.
- Generated mutation composables now emit `wpMutation('Name', ...)` instead of `useGraphqlMutation('Name', ...)`, sourced from `#wpnuxt-internal`.
- New module alias `#wpnuxt-internal` registered for both Vite and Nitro (chose `-internal` rather than `/internal` to avoid the existing `#wpnuxt/*` wildcard collision).
- `useGraphqlMutation` stub added to `packages/core/src/runtime/types/stub.d.ts` so the new wrapper typechecks standalone.

## Why

`nuxt-graphql-middleware` is pinned to exact `5.4.0` and is a single-maintainer project. Before this change, every composable called the upstream APIs directly. A breaking 5.5 release now requires updating one file instead of every call site. It also gives us a chokepoint for upcoming work like the `wpnuxt:query` telemetry hook (#263).

## Public API impact

None. `useWPContent`, `useWPConnection`, the generated query/mutation composables, and direct user-code calls to `useGraphqlMutation` (auto-imported via `nuxt-graphql-middleware`'s `includeComposables: true`) all behave identically.

## Test plan

- [x] `pnpm run check` passes locally (dev:prepare → lint → typecheck → test → build, all 4 playgrounds build clean).
- [x] New `packages/core/test/internal/graphql-client.test.ts` verifies `wpQuery`/`wpMutation` forward arguments unchanged and preserve thenable behavior.
- [x] Existing `useWPContent.test.ts` / `useWPConnection.test.ts` / `usePrevNextPost.test.ts` updated to include `useGraphqlMutation` in their `#imports` mocks (transitive import from the new wrapper).
- [x] Existing `generate.test.ts` updated to assert the new `wpMutation('Login'` template and the `#wpnuxt-internal` import line.
- [ ] Smoke test in `pnpm run dev:full` — confirm `usePosts()` and any mutation-using component work unchanged.