### PR TITLE
feat(core): emit wpnuxt:query hook for runtime telemetry

### DIFF
--- a/packages/core/src/runtime/internal/graphql-client.ts
+++ b/packages/core/src/runtime/internal/graphql-client.ts
@@ -1,17 +1,112 @@
-import { useAsyncGraphqlQuery, useGraphqlMutation } from '#imports'
+import type { Ref } from 'vue'
+import { useAsyncGraphqlQuery, useGraphqlMutation, useNuxtApp, watch, toValue } from '#imports'
+
+/**
+ * Payload for the `wpnuxt:query` runtime telemetry hook.
+ */
+export interface WPNuxtQueryHookPayload {
+  queryName: string
+  queryType: 'query' | 'mutation'
+  variables: Record<string, unknown> | undefined
+  durationMs: number
+  status: 'success' | 'error'
+  error?: Error
+}
+
+type UseAsyncGraphqlQuery = typeof useAsyncGraphqlQuery
+type UseGraphqlMutation = typeof useGraphqlMutation
+type NuxtAppLike = { callHook?: (name: string, ...args: unknown[]) => Promise<void> | void }
 
 /**
  * Internal GraphQL client surface for @wpnuxt/core.
  *
- * Centralizes the integration with nuxt-graphql-middleware so future upstream
- * changes can be absorbed in this single file rather than every call site.
- * Today these are direct re-exports; runtime instrumentation (e.g. telemetry
- * hooks) will be layered here.
+ * Centralizes the integration with nuxt-graphql-middleware and emits the
+ * `wpnuxt:query` telemetry hook on every completed fetch so user code can
+ * wire Sentry, Datadog, OpenTelemetry, or custom logging without WPNuxt
+ * depending on any of them. Cache hits never fire (pending stays false);
+ * refresh/execute fire per attempt.
  *
  * Not part of the public API — exposed via the `#wpnuxt-internal` alias only
- * for use by generated mutation composables. Consumers should keep using
- * `useWPContent`, `useWPConnection`, the generated query composables, or call
- * `useGraphqlMutation` directly (auto-imported via nuxt-graphql-middleware).
+ * for generated mutation composables and the internal `useWPContent`
+ * composable.
  */
-export const wpQuery = useAsyncGraphqlQuery
-export const wpMutation = useGraphqlMutation
+export const wpQuery = ((...args: Parameters<UseAsyncGraphqlQuery>): ReturnType<UseAsyncGraphqlQuery> => {
+  const [name, variables] = args
+  const nuxtApp = useNuxtApp() as NuxtAppLike
+  const result = useAsyncGraphqlQuery(...args)
+
+  // Track a single fetch cycle: pending true → false fires the hook once.
+  // Initial state with cache-hit has pending=false and never flips, so no hook.
+  // Explicit refresh()/execute() re-enter the cycle and fire again per attempt.
+  let wasPending = false
+  let cycleStart = 0
+  const pendingSource = (result as unknown as { pending: Ref<boolean> }).pending
+  const errorSource = (result as unknown as { error?: Ref<unknown> }).error
+  watch(
+    pendingSource,
+    (isPending: boolean) => {
+      if (isPending) {
+        wasPending = true
+        cycleStart = performance.now()
+        return
+      }
+      if (!wasPending) return
+      wasPending = false
+      const errorVal = errorSource?.value instanceof Error ? errorSource.value : undefined
+      emitHook(nuxtApp, {
+        queryName: String(name),
+        queryType: 'query',
+        variables: normalizeVariables(variables),
+        durationMs: performance.now() - cycleStart,
+        status: errorVal ? 'error' : 'success',
+        ...(errorVal ? { error: errorVal } : {})
+      })
+    },
+    { immediate: true }
+  )
+
+  return result
+}) as unknown as UseAsyncGraphqlQuery
+
+export const wpMutation = ((...args: Parameters<UseGraphqlMutation>): ReturnType<UseGraphqlMutation> => {
+  const [name, variables] = args
+  const nuxtApp = useNuxtApp() as NuxtAppLike
+  const startTime = performance.now()
+  const promise = useGraphqlMutation(...args)
+  Promise.resolve(promise).then(
+    () => emitHook(nuxtApp, {
+      queryName: String(name),
+      queryType: 'mutation',
+      variables: normalizeVariables(variables),
+      durationMs: performance.now() - startTime,
+      status: 'success'
+    }),
+    (err: unknown) => emitHook(nuxtApp, {
+      queryName: String(name),
+      queryType: 'mutation',
+      variables: normalizeVariables(variables),
+      durationMs: performance.now() - startTime,
+      status: 'error',
+      error: err instanceof Error ? err : new Error(String(err))
+    })
+  )
+  return promise
+}) as unknown as UseGraphqlMutation
+
+function normalizeVariables(variables: unknown): Record<string, unknown> | undefined {
+  const value = toValue(variables)
+  if (value && typeof value === 'object') return value as Record<string, unknown>
+  return undefined
+}
+
+function emitHook(nuxtApp: NuxtAppLike, payload: WPNuxtQueryHookPayload) {
+  if (typeof nuxtApp?.callHook !== 'function') return
+  const maybePromise = nuxtApp.callHook('wpnuxt:query', payload)
+  if (maybePromise && typeof (maybePromise as PromiseLike<void>).then === 'function') {
+    Promise.resolve(maybePromise).catch((err: unknown) => {
+      if (import.meta.dev) {
+        console.warn('[wpnuxt] wpnuxt:query hook handler threw', err)
+      }
+    })
+  }
+}

--- a/packages/core/src/types/nuxt-augment.d.ts
+++ b/packages/core/src/types/nuxt-augment.d.ts
@@ -34,6 +34,31 @@ declare module 'nuxt/schema' {
 declare module '@nuxt/schema' {
   interface NuxtHooks {
     'devtools:customTabs': (tabs: Array<{ name: string, title?: string, icon?: string }>) => void
+    /**
+     * Fired on every WPNuxt-mediated GraphQL request completion.
+     *
+     * Emitted once per fetch attempt (refresh/execute fire again; cache hits
+     * do not fire). Fire-and-forget — handler errors are isolated and logged
+     * only in development.
+     *
+     * @example
+     * ```ts
+     * // plugins/wpnuxt-telemetry.ts
+     * export default defineNuxtPlugin((nuxtApp) => {
+     *   nuxtApp.hook('wpnuxt:query', (payload) => {
+     *     console.log(`[gql] ${payload.queryType} ${payload.queryName} ${payload.status} (${payload.durationMs}ms)`)
+     *   })
+     * })
+     * ```
+     */
+    'wpnuxt:query': (payload: {
+      queryName: string
+      queryType: 'query' | 'mutation'
+      variables: Record<string, unknown> | undefined
+      durationMs: number
+      status: 'success' | 'error'
+      error?: Error
+    }) => void | Promise<void>
   }
 }
 

--- a/packages/core/test/internal/graphql-client.test.ts
+++ b/packages/core/test/internal/graphql-client.test.ts
@@ -1,57 +1,233 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ref, watch as vueWatch, nextTick } from 'vue'
 
 const mockUseAsyncGraphqlQuery = vi.fn()
 const mockUseGraphqlMutation = vi.fn()
+const mockCallHook = vi.fn<(name: string, payload: unknown) => Promise<void>>(() => Promise.resolve())
+const mockUseNuxtApp = vi.fn(() => ({ callHook: mockCallHook }))
 
 vi.mock('#imports', () => ({
   useAsyncGraphqlQuery: mockUseAsyncGraphqlQuery,
-  useGraphqlMutation: mockUseGraphqlMutation
+  useGraphqlMutation: mockUseGraphqlMutation,
+  useNuxtApp: mockUseNuxtApp,
+  watch: vueWatch,
+  toValue: (v: unknown) => (typeof v === 'function' ? (v as () => unknown)() : v)
 }))
+
+vi.stubGlobal('import', { meta: { dev: true } })
+
+function makeAsyncResult(overrides: Record<string, unknown> = {}) {
+  return {
+    data: ref<unknown>(null),
+    pending: ref(false),
+    error: ref<Error | null>(null),
+    status: ref<'idle' | 'pending' | 'success' | 'error'>('idle'),
+    refresh: vi.fn().mockResolvedValue(undefined),
+    execute: vi.fn().mockResolvedValue(undefined),
+    clear: vi.fn(),
+    ...overrides
+  }
+}
 
 describe('internal/graphql-client', () => {
   beforeEach(() => {
     vi.resetModules()
     mockUseAsyncGraphqlQuery.mockReset()
     mockUseGraphqlMutation.mockReset()
+    mockCallHook.mockReset()
+    mockCallHook.mockImplementation(() => Promise.resolve())
   })
 
-  it('wpQuery forwards arguments to useAsyncGraphqlQuery and returns its result', async () => {
-    const sentinelResult = { data: { value: { posts: { nodes: [] } } } }
-    mockUseAsyncGraphqlQuery.mockReturnValue(sentinelResult)
+  describe('wpQuery', () => {
+    it('forwards arguments to useAsyncGraphqlQuery and returns its result', async () => {
+      const sentinel = makeAsyncResult()
+      mockUseAsyncGraphqlQuery.mockReturnValue(sentinel)
 
-    const { wpQuery } = await import('../../src/runtime/internal/graphql-client')
-    const params = { uri: '/hello-world/' }
-    const options = { lazy: true }
-    const result = wpQuery('Posts' as never, params as never, options as never)
+      const { wpQuery } = await import('../../src/runtime/internal/graphql-client')
+      const params = { uri: '/hello-world/' }
+      const options = { lazy: true }
+      const result = wpQuery('Posts' as never, params as never, options as never)
 
-    expect(mockUseAsyncGraphqlQuery).toHaveBeenCalledTimes(1)
-    expect(mockUseAsyncGraphqlQuery).toHaveBeenCalledWith('Posts', params, options)
-    expect(result).toBe(sentinelResult)
+      expect(mockUseAsyncGraphqlQuery).toHaveBeenCalledTimes(1)
+      expect(mockUseAsyncGraphqlQuery).toHaveBeenCalledWith('Posts', params, options)
+      expect(result).toBe(sentinel)
+    })
+
+    it('fires wpnuxt:query hook on fetch completion with success status', async () => {
+      const sentinel = makeAsyncResult()
+      mockUseAsyncGraphqlQuery.mockReturnValue(sentinel)
+
+      const { wpQuery } = await import('../../src/runtime/internal/graphql-client')
+      wpQuery('Posts' as never, { first: 10 } as never, {} as never)
+
+      // Simulate a fetch cycle
+      sentinel.pending.value = true
+      await nextTick()
+      sentinel.pending.value = false
+      await nextTick()
+
+      expect(mockCallHook).toHaveBeenCalledTimes(1)
+      expect(mockCallHook).toHaveBeenCalledWith('wpnuxt:query', expect.objectContaining({
+        queryName: 'Posts',
+        queryType: 'query',
+        variables: { first: 10 },
+        status: 'success',
+        durationMs: expect.any(Number)
+      }))
+      const payload = mockCallHook.mock.calls[0]![1] as unknown as { durationMs: number, error?: Error }
+      expect(payload.durationMs).toBeGreaterThanOrEqual(0)
+      expect(payload.error).toBeUndefined()
+    })
+
+    it('fires wpnuxt:query hook with error status when the request fails', async () => {
+      const sentinel = makeAsyncResult()
+      mockUseAsyncGraphqlQuery.mockReturnValue(sentinel)
+
+      const { wpQuery } = await import('../../src/runtime/internal/graphql-client')
+      wpQuery('Posts' as never, {} as never, {} as never)
+
+      const fetchErr = new Error('Network down')
+      sentinel.pending.value = true
+      await nextTick()
+      sentinel.error.value = fetchErr
+      sentinel.pending.value = false
+      await nextTick()
+
+      expect(mockCallHook).toHaveBeenCalledTimes(1)
+      const [hookName, payload] = mockCallHook.mock.calls[0]! as unknown as [string, { status: string, error: Error }]
+      expect(hookName).toBe('wpnuxt:query')
+      expect(payload.status).toBe('error')
+      expect(payload.error).toBe(fetchErr)
+    })
+
+    it('does not fire the hook on cache hits (pending never becomes true)', async () => {
+      const sentinel = makeAsyncResult()
+      mockUseAsyncGraphqlQuery.mockReturnValue(sentinel)
+
+      const { wpQuery } = await import('../../src/runtime/internal/graphql-client')
+      wpQuery('Posts' as never, {} as never, {} as never)
+
+      // pending stays false throughout — simulates a cache hit
+      await nextTick()
+      sentinel.pending.value = false
+      await nextTick()
+
+      expect(mockCallHook).not.toHaveBeenCalled()
+    })
+
+    it('fires the hook once per refresh attempt', async () => {
+      const sentinel = makeAsyncResult()
+      mockUseAsyncGraphqlQuery.mockReturnValue(sentinel)
+
+      const { wpQuery } = await import('../../src/runtime/internal/graphql-client')
+      wpQuery('Posts' as never, {} as never, {} as never)
+
+      // First fetch
+      sentinel.pending.value = true
+      await nextTick()
+      sentinel.pending.value = false
+      await nextTick()
+
+      // Refresh
+      sentinel.pending.value = true
+      await nextTick()
+      sentinel.pending.value = false
+      await nextTick()
+
+      expect(mockCallHook).toHaveBeenCalledTimes(2)
+    })
+
+    it('resolves reactive variables via toValue before emitting', async () => {
+      const sentinel = makeAsyncResult()
+      mockUseAsyncGraphqlQuery.mockReturnValue(sentinel)
+
+      const { wpQuery } = await import('../../src/runtime/internal/graphql-client')
+      const variablesGetter = () => ({ uri: '/hello-world/' })
+      wpQuery('PostByUri' as never, variablesGetter as never, {} as never)
+
+      sentinel.pending.value = true
+      await nextTick()
+      sentinel.pending.value = false
+      await nextTick()
+
+      const payload = mockCallHook.mock.calls[0]![1] as unknown as { variables: Record<string, unknown> }
+      expect(payload.variables).toEqual({ uri: '/hello-world/' })
+    })
   })
 
-  it('wpMutation forwards arguments to useGraphqlMutation and returns its result', async () => {
-    const sentinelResult = Promise.resolve({ data: { login: { authToken: 'x' } } })
-    mockUseGraphqlMutation.mockReturnValue(sentinelResult)
+  describe('wpMutation', () => {
+    it('forwards arguments to useGraphqlMutation and returns its result', async () => {
+      const sentinelPromise = Promise.resolve({ data: { login: { authToken: 'x' } } })
+      mockUseGraphqlMutation.mockReturnValue(sentinelPromise)
 
-    const { wpMutation } = await import('../../src/runtime/internal/graphql-client')
-    const variables = { username: 'a', password: 'b' }
-    const options = { fetchOptions: { headers: { 'X-Test': '1' } } }
-    const result = wpMutation('Login' as never, variables as never, options as never)
+      const { wpMutation } = await import('../../src/runtime/internal/graphql-client')
+      const variables = { username: 'a', password: 'b' }
+      const options = { fetchOptions: { headers: { 'X-Test': '1' } } }
+      const result = wpMutation('Login' as never, variables as never, options as never)
 
-    expect(mockUseGraphqlMutation).toHaveBeenCalledTimes(1)
-    expect(mockUseGraphqlMutation).toHaveBeenCalledWith('Login', variables, options)
-    expect(result).toBe(sentinelResult)
+      expect(mockUseGraphqlMutation).toHaveBeenCalledTimes(1)
+      expect(mockUseGraphqlMutation).toHaveBeenCalledWith('Login', variables, options)
+      expect(result).toBe(sentinelPromise)
+    })
+
+    it('fires wpnuxt:query hook with success status when mutation resolves', async () => {
+      const sentinelPromise = Promise.resolve({ data: { login: { authToken: 'x' } } })
+      mockUseGraphqlMutation.mockReturnValue(sentinelPromise)
+
+      const { wpMutation } = await import('../../src/runtime/internal/graphql-client')
+      wpMutation('Login' as never, { username: 'a' } as never, {} as never)
+
+      await sentinelPromise
+      await nextTick()
+
+      expect(mockCallHook).toHaveBeenCalledTimes(1)
+      expect(mockCallHook).toHaveBeenCalledWith('wpnuxt:query', expect.objectContaining({
+        queryName: 'Login',
+        queryType: 'mutation',
+        variables: { username: 'a' },
+        status: 'success',
+        durationMs: expect.any(Number)
+      }))
+    })
+
+    it('fires wpnuxt:query hook with error status when mutation rejects', async () => {
+      const mutationErr = new Error('Forbidden')
+      const rejectedPromise = Promise.reject(mutationErr)
+      // Prevent unhandled-rejection noise in the runner; wpMutation attaches its own handler.
+      rejectedPromise.catch(() => {})
+      mockUseGraphqlMutation.mockReturnValue(rejectedPromise)
+
+      const { wpMutation } = await import('../../src/runtime/internal/graphql-client')
+      const result = wpMutation('Login' as never, {} as never, {} as never)
+      await expect(result).rejects.toBe(mutationErr)
+      await nextTick()
+
+      expect(mockCallHook).toHaveBeenCalledTimes(1)
+      const [, payload] = mockCallHook.mock.calls[0]! as unknown as [string, { status: string, error: Error }]
+      expect(payload.status).toBe('error')
+      expect(payload.error).toBe(mutationErr)
+    })
   })
 
-  it('wpQuery preserves thenable behavior of the underlying result', async () => {
-    const refs = { data: { value: { posts: { nodes: [{ id: 1 }] } } } }
-    const thenable = Object.assign(Promise.resolve(refs), refs)
-    mockUseAsyncGraphqlQuery.mockReturnValue(thenable)
+  describe('hook handler isolation', () => {
+    it('does not throw when the user hook handler rejects', async () => {
+      mockCallHook.mockImplementation(() => Promise.reject(new Error('handler exploded')))
+      const sentinel = makeAsyncResult()
+      mockUseAsyncGraphqlQuery.mockReturnValue(sentinel)
 
-    const { wpQuery } = await import('../../src/runtime/internal/graphql-client')
-    const result = wpQuery('Posts' as never, {} as never, {} as never)
+      const { wpQuery } = await import('../../src/runtime/internal/graphql-client')
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
-    expect(result).toBe(thenable)
-    await expect(Promise.resolve(result)).resolves.toBe(refs)
+      expect(() => wpQuery('Posts' as never, {} as never, {} as never)).not.toThrow()
+      sentinel.pending.value = true
+      await nextTick()
+      sentinel.pending.value = false
+      await nextTick()
+      // Flush the catch
+      await Promise.resolve()
+
+      expect(mockCallHook).toHaveBeenCalledTimes(1)
+      warnSpy.mockRestore()
+    })
   })
 })

--- a/packages/core/test/usePrevNextPost.test.ts
+++ b/packages/core/test/usePrevNextPost.test.ts
@@ -8,6 +8,7 @@ vi.mock('#imports', () => ({
   watch: vi.fn(),
   useAsyncGraphqlQuery: vi.fn(),
   useGraphqlMutation: vi.fn(),
+  useNuxtApp: vi.fn(() => ({ callHook: vi.fn() })),
   useRuntimeConfig: vi.fn(() => ({ public: { wpNuxt: {} } }))
 }))
 
@@ -58,6 +59,7 @@ describe('usePrevNextPost', () => {
       watch: vi.fn(),
       useAsyncGraphqlQuery: mockUseAsyncGraphqlQuery,
       useGraphqlMutation: vi.fn(),
+      useNuxtApp: vi.fn(() => ({ callHook: vi.fn() })),
       useRuntimeConfig: vi.fn(() => ({ public: { wpNuxt: {} } }))
     }))
   })
@@ -127,6 +129,7 @@ describe('usePrevNextPost', () => {
       watch: vi.fn(),
       useAsyncGraphqlQuery: mockUseAsyncGraphqlQuery,
       useGraphqlMutation: vi.fn(),
+      useNuxtApp: vi.fn(() => ({ callHook: vi.fn() })),
       useRuntimeConfig: vi.fn(() => ({ public: { wpNuxt: {} } }))
     }))
 

--- a/packages/core/test/useWPConnection.test.ts
+++ b/packages/core/test/useWPConnection.test.ts
@@ -9,6 +9,7 @@ vi.mock('#imports', () => ({
   watch: vi.fn(),
   useAsyncGraphqlQuery: vi.fn(),
   useGraphqlMutation: vi.fn(),
+  useNuxtApp: vi.fn(() => ({ callHook: vi.fn() })),
   useRuntimeConfig: vi.fn(() => ({ public: { wpNuxt: {} } }))
 }))
 
@@ -71,6 +72,7 @@ describe('useWPConnection', () => {
       watch: vi.fn(),
       useAsyncGraphqlQuery: mockUseAsyncGraphqlQuery,
       useGraphqlMutation: vi.fn(),
+      useNuxtApp: vi.fn(() => ({ callHook: vi.fn() })),
       useRuntimeConfig: vi.fn(() => ({ public: { wpNuxt: {} } }))
     }))
   })
@@ -129,6 +131,7 @@ describe('useWPConnection', () => {
       watch: vi.fn(),
       useAsyncGraphqlQuery: mockUseAsyncGraphqlQuery,
       useGraphqlMutation: vi.fn(),
+      useNuxtApp: vi.fn(() => ({ callHook: vi.fn() })),
       useRuntimeConfig: vi.fn(() => ({ public: { wpNuxt: {} } }))
     }))
 
@@ -165,6 +168,7 @@ describe('useWPConnection', () => {
       watch: vi.fn(),
       useAsyncGraphqlQuery: mockUseAsyncGraphqlQuery,
       useGraphqlMutation: vi.fn(),
+      useNuxtApp: vi.fn(() => ({ callHook: vi.fn() })),
       useRuntimeConfig: vi.fn(() => ({ public: { wpNuxt: {} } }))
     }))
 

--- a/packages/core/test/useWPContent.test.ts
+++ b/packages/core/test/useWPContent.test.ts
@@ -16,8 +16,10 @@ vi.mock('#imports', () => ({
   computed: vi.fn(fn => ({ value: fn() })),
   ref: vi.fn(val => ({ value: val })),
   watch: vi.fn(),
+  toValue: vi.fn(val => val),
   useAsyncGraphqlQuery: vi.fn(),
   useGraphqlMutation: vi.fn(),
+  useNuxtApp: vi.fn(() => ({ callHook: vi.fn() })),
   useRuntimeConfig: vi.fn(() => ({ public: { wpNuxt: {} } }))
 }))
 
@@ -74,8 +76,10 @@ describe('useWPContent', () => {
       }),
       ref: mockRef,
       watch: mockWatch,
+      toValue: vi.fn(val => val),
       useAsyncGraphqlQuery: mockUseAsyncGraphqlQuery,
       useGraphqlMutation: vi.fn(),
+      useNuxtApp: vi.fn(() => ({ callHook: vi.fn() })),
       useRuntimeConfig: vi.fn(() => ({ public: { wpNuxt: {} } }))
     }))
   })
@@ -126,9 +130,11 @@ describe('useWPContent', () => {
 
       useWPContent('Posts', ['posts', 'nodes'], false, {}, { retry: false })
 
-      // Verify maxRetries is 0 when retry is false
-      // This is tested implicitly by checking that no retry-related watch is set up
-      expect(mockWatch).toHaveBeenCalledTimes(0)
+      // wpQuery always registers a telemetry watch on `pending` with
+      // { immediate: true }; filter that out and assert no retry-specific
+      // watch (on the error ref) was registered.
+      const retryWatchCalls = mockWatch.mock.calls.filter(call => !(call[2] as { immediate?: boolean } | undefined)?.immediate)
+      expect(retryWatchCalls).toHaveLength(0)
     })
 
     it('should use custom retryDelay when provided', async () => {


### PR DESCRIPTION
Closes #263.

## Summary

Fires a typed Nuxt hook `wpnuxt:query` on every WPNuxt-mediated GraphQL request with timing and status, so user code can wire external telemetry (Sentry, Datadog, OpenTelemetry, custom logs) without WPNuxt depending on any of them.

```ts
// plugins/wpnuxt-telemetry.ts
export default defineNuxtPlugin((nuxtApp) => {
  nuxtApp.hook('wpnuxt:query', (payload) => {
    console.log(`[gql] ${payload.queryType} ${payload.queryName} ${payload.status} (${payload.durationMs}ms)`)
  })
})
```

## Payload

```ts
{
  queryName: string
  queryType: 'query' | 'mutation'
  variables: Record<string, unknown> | undefined
  durationMs: number
  status: 'success' | 'error'
  error?: Error
}
```

Declared via module augmentation on `@nuxt/schema`'s `NuxtHooks`, so `nuxtApp.hook('wpnuxt:query', ...)` is fully typed in user projects.

## Behaviour

- **Cache hits do not fire.** Instrumentation watches `pending`; cache hits never flip it to true.
- **`refresh()` / `execute()` fire per attempt.** One hook call per fetch cycle.
- **Mutations fire on both resolve and reject.**
- **Fire-and-forget.** A user handler that throws is isolated and logged only in `import.meta.dev`.

## Implementation

Instrumentation lives in `packages/core/src/runtime/internal/graphql-client.ts` — the wrapper introduced in #262 is the single chokepoint so both `useWPContent` callers and generated mutation composables get telemetry without duplicating logic.

`wpQuery` watches the underlying `AsyncData.pending` ref (true → false transition) to time a cycle and read `error` at completion. `wpMutation` times the mutation promise directly.

## Public API impact

Additive only. The hook is new; existing composables and generated code are unchanged.

## Test plan

- [x] `pnpm run check` passes locally (255/255 core tests, all 4 playgrounds build clean).
- [x] New tests in `packages/core/test/internal/graphql-client.test.ts` cover: success firing, error firing, cache-hit skip, per-refresh firing, reactive-variable resolution via `toValue`, mutation success + reject, and handler-isolation (user handler throws — wpQuery does not).
- [x] Existing composable mocks updated to include `useNuxtApp` so transitive loads of the wrapper don't break.
- [x] `useWPContent` "no retry watcher" test adjusted — wpQuery now always registers a telemetry watch with `{ immediate: true }`; the test now filters that out and asserts no retry watcher was added.
- [ ] Smoke test in `pnpm run dev:full`: register `nuxtApp.hook('wpnuxt:query', p => console.log(p))` in a plugin, navigate, confirm a single log per page with shape `{ queryName: 'Posts', queryType: 'query', durationMs: <ms>, status: 'success', ... }`.