### PR TITLE
refactor(core): generate composable types via TypeScript AST with schema validation

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -62,7 +62,8 @@
     "dompurify": "^3.4.0",
     "graphql": "^16.13.2",
     "nuxt-graphql-middleware": "5.4.0",
-    "scule": "^1.3.0"
+    "scule": "^1.3.0",
+    "typescript": "^5.9.3"
   },
   "devDependencies": {
     "@nuxt/devtools": "^3.2.3",

--- a/packages/core/src/generate.ts
+++ b/packages/core/src/generate.ts
@@ -3,9 +3,11 @@ import { resolveFiles } from '@nuxt/kit'
 import type { Resolver } from '@nuxt/kit'
 import { upperFirst } from 'scule'
 import type { Import } from 'unimport'
+import type ts from 'typescript'
 import type { WPNuxtContext, WPNuxtQuery } from './types/queries'
 import { getLogger } from './utils/index'
 import { parseDoc } from './utils/useParser'
+import { arrayOf, indexedAccess, nonNullable, numberIndexedAccess, printType, typeRef, unionOrSingle, withImagePath } from './utils/typegen'
 
 // Cache regex for performance
 const SCHEMA_PATTERN = /schema\.(?:gql|graphql)$/i
@@ -94,49 +96,54 @@ export async function prepareContext(ctx: WPNuxtContext) {
   const formatNodes = (nodes?: string[]) => nodes?.map(n => `'${n}'`).join(',') ?? ''
 
   /**
-   * Get the return type for a query.
-   * - Queries with fragments: use fragment types (e.g., PostFragment[])
-   * - Queries without fragments: use the query's root type with path accessors
+   * Build the TypeScript return type for a query as an AST node. Printed to a
+   * string immediately below; the intermediate AST keeps the shape machine-
+   * checkable so malformed output is a TypeScript error here rather than a
+   * cryptic error downstream in user code.
+   *
+   * - Queries with fragments only: fragment types (e.g. `PostFragment[]`)
+   * - Queries with inline fields or no fragments: root query type with path
+   *   accessors (e.g. `NonNullable<PostsRootQuery>['posts']['nodes'][number]`)
    */
-  const getFragmentType = (q: WPNuxtQuery) => {
-    // Connection queries: return singular type (WPConnectionResult adds the array)
+  const buildFragmentTypeNode = (q: WPNuxtQuery): ts.TypeNode => {
     if (q.hasPageInfo) {
       if (q.hasInlineFields || !q.fragments?.length) {
         if (q.nodes?.length) {
-          let typePath = `${q.name}RootQuery`
-          for (const node of q.nodes) {
-            typePath = `NonNullable<${typePath}>['${node}']`
+          let node: ts.TypeNode = typeRef(`${q.name}RootQuery`)
+          for (const segment of q.nodes) {
+            node = indexedAccess(nonNullable(node), segment)
           }
-          // Drill into nodes[number] to get the item type
-          typePath = `NonNullable<${typePath}>['nodes'][number]`
-          return typePath
+          // Drill into `.nodes[number]` to get the item type
+          return numberIndexedAccess(indexedAccess(nonNullable(node), 'nodes'))
         }
-        return `${q.name}RootQuery`
+        return typeRef(`${q.name}RootQuery`)
       }
-      // Fragments only — singular type (no [])
-      return q.fragments.map(f => `WithImagePath<${f}Fragment>`).join(' | ')
+      // Fragments only — singular type (WPConnectionResult<T> adds the array)
+      return unionOrSingle(q.fragments.map(f => withImagePath(typeRef(`${f}Fragment`))))
     }
 
-    // If query has both fragments AND inline fields, use the full query type
-    // to preserve the intersection of fragment types + custom fields
     if (q.hasInlineFields || !q.fragments?.length) {
       if (q.nodes?.length) {
-        let typePath = `${q.name}RootQuery`
-        for (const node of q.nodes) {
-          typePath = `NonNullable<${typePath}>['${node}']`
+        let node: ts.TypeNode = typeRef(`${q.name}RootQuery`)
+        for (const segment of q.nodes) {
+          node = indexedAccess(nonNullable(node), segment)
         }
         if (q.nodes.includes('nodes')) {
-          typePath = `${typePath}[number]`
+          node = numberIndexedAccess(node)
         }
-        return typePath
+        return node
       }
-      return `${q.name}RootQuery`
+      return typeRef(`${q.name}RootQuery`)
     }
 
-    // Fragments only — use fragment union types
-    const fragmentSuffix = q.nodes?.includes('nodes') ? '[]' : ''
-    return q.fragments.map(f => `WithImagePath<${f}Fragment>${fragmentSuffix}`).join(' | ')
+    const fragmentTypes = q.fragments.map(f => withImagePath(typeRef(`${f}Fragment`)))
+    if (q.nodes?.includes('nodes')) {
+      return unionOrSingle(fragmentTypes.map(arrayOf))
+    }
+    return unionOrSingle(fragmentTypes)
   }
+
+  const getFragmentType = (q: WPNuxtQuery) => printType(buildFragmentTypeNode(q))
 
   // Query composable expression
   const queryFnExp = (q: WPNuxtQuery, typed = false) => {
@@ -221,6 +228,10 @@ export async function prepareContext(ctx: WPNuxtContext) {
     typeSet.add(`${m.name}MutationVariables`)
     typeSet.add(`${m.name}Mutation`)
   })
+
+  // Expose for post-generation schema-drift validation
+  // (see utils/validateGenerated.ts, wired in module.ts)
+  ctx.referencedTypes = [...typeSet]
 
   ctx.generateDeclarations = () => {
     const declarations = [

--- a/packages/core/src/module.ts
+++ b/packages/core/src/module.ts
@@ -13,6 +13,7 @@ import type { WPNuxtContext } from './types/queries'
 import { generateWPNuxtComposables } from './generate'
 import { getLogger, initLogger, mergeQueries, randHashGenerator, createModuleError, validateWordPressUrl } from './utils/index'
 import { validateWordPressEndpoint } from './utils/endpointValidation'
+import { validateGeneratedPaths } from './utils/validateGenerated'
 import { runInstall } from './install'
 
 /**
@@ -304,6 +305,22 @@ export default defineNuxtModule<WPNuxtConfig>({
       autoimports.push(...(ctx.fnImports || []))
     })
     logger.trace('Finished generating composables')
+
+    // Validate that generated type references exist in nuxt-graphql-middleware's
+    // operations declaration file. On cold builds the file may not exist yet;
+    // skip silently in that case — subsequent builds catch any drift.
+    nuxt.hook('build:before', () => {
+      if (!ctx.referencedTypes?.length) return
+      const operationsDtsPath = join(nuxt.options.buildDir, 'graphql-operations.d.ts')
+      const result = validateGeneratedPaths(ctx.referencedTypes, operationsDtsPath)
+      if (result.skipped || result.dangling.length === 0) return
+      logger.warn(
+        `WPNuxt generated composables reference ${result.dangling.length} type(s) not declared in graphql-operations.d.ts. `
+        + 'This usually means your WordPress GraphQL schema has drifted from your queries; '
+        + 'delete schema.graphql to force a fresh download, then re-run pnpm dev:prepare.'
+      )
+      for (const t of result.dangling) logger.warn(`  - ${t}`)
+    })
 
     logger.info(`WPNuxt module loaded in ${new Date().getTime() - startTime}ms`)
   },

--- a/packages/core/src/types/queries.ts
+++ b/packages/core/src/types/queries.ts
@@ -40,4 +40,10 @@ export interface WPNuxtContext {
   generateImports?: () => string
   generateDeclarations?: () => string
   docs?: string[]
+  /**
+   * Top-level type identifiers referenced by the generated `.d.ts` that
+   * must resolve against `graphql-operations.d.ts`. Populated by
+   * `prepareContext()`; consumed by `validateGeneratedPaths()`.
+   */
+  referencedTypes?: string[]
 }

--- a/packages/core/src/utils/typegen.ts
+++ b/packages/core/src/utils/typegen.ts
@@ -1,0 +1,60 @@
+import ts from 'typescript'
+
+const { factory, SyntaxKind, NewLineKind, EmitHint, ScriptTarget } = ts
+
+/**
+ * Small typed wrappers around `ts.factory` for the TypeScript type-path
+ * shapes WPNuxt's generator emits. Using the AST instead of string
+ * concatenation means misshapen output is a TypeScript compiler error,
+ * not a cryptic error downstream in user code.
+ */
+
+export function typeRef(name: string, typeArguments?: ts.TypeNode[]): ts.TypeReferenceNode {
+  return factory.createTypeReferenceNode(name, typeArguments)
+}
+
+export function nonNullable(node: ts.TypeNode): ts.TypeNode {
+  return typeRef('NonNullable', [node])
+}
+
+export function withImagePath(node: ts.TypeNode): ts.TypeNode {
+  return typeRef('WithImagePath', [node])
+}
+
+export function indexedAccess(target: ts.TypeNode, key: string): ts.TypeNode {
+  return factory.createIndexedAccessTypeNode(
+    target,
+    // `isSingleQuote` preserves the single-quote style the generator used
+    // before this module was AST-based — keeps generated .d.ts text-stable.
+    factory.createLiteralTypeNode(factory.createStringLiteral(key, true))
+  )
+}
+
+export function numberIndexedAccess(target: ts.TypeNode): ts.TypeNode {
+  return factory.createIndexedAccessTypeNode(
+    target,
+    factory.createKeywordTypeNode(SyntaxKind.NumberKeyword)
+  )
+}
+
+export function arrayOf(node: ts.TypeNode): ts.TypeNode {
+  return factory.createArrayTypeNode(node)
+}
+
+export function unionOrSingle(nodes: ts.TypeNode[]): ts.TypeNode {
+  if (nodes.length === 0) {
+    throw new Error('unionOrSingle: empty type list')
+  }
+  if (nodes.length === 1) return nodes[0]!
+  return factory.createUnionTypeNode(nodes)
+}
+
+const printer = ts.createPrinter({ newLine: NewLineKind.LineFeed, removeComments: false })
+const syntheticFile = ts.createSourceFile('__synthetic.ts', '', ScriptTarget.Latest)
+
+/**
+ * Print a TypeScript type node to a string for embedding in generated source.
+ */
+export function printType(node: ts.TypeNode): string {
+  return printer.printNode(EmitHint.Unspecified, node, syntheticFile)
+}

--- a/packages/core/src/utils/validateGenerated.ts
+++ b/packages/core/src/utils/validateGenerated.ts
@@ -1,0 +1,67 @@
+import { existsSync, readFileSync } from 'node:fs'
+import ts from 'typescript'
+
+export interface GeneratedPathValidationResult {
+  /** True if the operations declaration file doesn't exist yet — nothing to validate against. */
+  skipped: boolean
+  /** Top-level type identifiers referenced by the generator that are not declared in the operations file. */
+  dangling: string[]
+}
+
+/**
+ * Validate that the top-level type identifiers referenced by WPNuxt's generated
+ * composables exist in nuxt-graphql-middleware's `graphql-operations.d.ts`.
+ *
+ * Dangling references indicate schema drift between the merged queries and the
+ * live WordPress GraphQL schema — typically because a query selects a field or
+ * fragment that no longer exists. Today the symptom is a cryptic TypeScript
+ * error in user code; this surfaces it as a build-time warning in the module.
+ *
+ * Scope is intentionally conservative: only top-level identifiers declared by
+ * `graphql-operations.d.ts` (type aliases, interfaces, consts) are checked.
+ * Deeper path walks (e.g. `NonNullable<X>['field']['nodes'][number]`) are out
+ * of scope for this pass — they would require the full TypeScript type
+ * checker, which is disproportionate for the value.
+ */
+export function validateGeneratedPaths(
+  referencedTypes: Iterable<string>,
+  operationsDtsPath: string
+): GeneratedPathValidationResult {
+  if (!existsSync(operationsDtsPath)) {
+    return { skipped: true, dangling: [] }
+  }
+
+  const source = readFileSync(operationsDtsPath, 'utf8')
+  const sourceFile = ts.createSourceFile(
+    operationsDtsPath,
+    source,
+    ts.ScriptTarget.Latest,
+    false
+  )
+
+  const declared = new Set<string>()
+  const visit = (node: ts.Node) => {
+    if (ts.isTypeAliasDeclaration(node) || ts.isInterfaceDeclaration(node) || ts.isClassDeclaration(node)) {
+      if (node.name) declared.add(node.name.text)
+    } else if (ts.isVariableStatement(node)) {
+      for (const d of node.declarationList.declarations) {
+        if (ts.isIdentifier(d.name)) declared.add(d.name.text)
+      }
+    } else if (ts.isModuleDeclaration(node) && node.body && ts.isModuleBlock(node.body)) {
+      // Walk into `declare module '...' { ... }` blocks so re-declared
+      // symbols are counted too.
+      for (const child of node.body.statements) visit(child)
+    }
+  }
+  for (const stmt of sourceFile.statements) visit(stmt)
+
+  const dangling: string[] = []
+  const seen = new Set<string>()
+  for (const ref of referencedTypes) {
+    if (seen.has(ref)) continue
+    seen.add(ref)
+    if (!declared.has(ref)) dangling.push(ref)
+  }
+
+  return { skipped: false, dangling }
+}

--- a/packages/core/test/typegen.test.ts
+++ b/packages/core/test/typegen.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest'
+import {
+  arrayOf,
+  indexedAccess,
+  nonNullable,
+  numberIndexedAccess,
+  printType,
+  typeRef,
+  unionOrSingle,
+  withImagePath
+} from '../src/utils/typegen'
+
+describe('typegen', () => {
+  describe('typeRef', () => {
+    it('prints a bare identifier', () => {
+      expect(printType(typeRef('PostFragment'))).toBe('PostFragment')
+    })
+
+    it('prints a generic instantiation', () => {
+      expect(printType(typeRef('Array', [typeRef('Post')]))).toBe('Array<Post>')
+    })
+  })
+
+  describe('nonNullable', () => {
+    it('wraps a type in NonNullable<>', () => {
+      expect(printType(nonNullable(typeRef('PostsRootQuery')))).toBe('NonNullable<PostsRootQuery>')
+    })
+  })
+
+  describe('withImagePath', () => {
+    it('wraps a type in WithImagePath<>', () => {
+      expect(printType(withImagePath(typeRef('PostFragment')))).toBe('WithImagePath<PostFragment>')
+    })
+  })
+
+  describe('indexedAccess', () => {
+    it('emits a string-literal indexed access', () => {
+      const node = indexedAccess(nonNullable(typeRef('PostsRootQuery')), 'posts')
+      expect(printType(node)).toBe(`NonNullable<PostsRootQuery>['posts']`)
+    })
+
+    it('chains', () => {
+      const node = indexedAccess(indexedAccess(nonNullable(typeRef('PostsRootQuery')), 'posts'), 'nodes')
+      expect(printType(node)).toBe(`NonNullable<PostsRootQuery>['posts']['nodes']`)
+    })
+  })
+
+  describe('numberIndexedAccess', () => {
+    it('emits [number]', () => {
+      const node = numberIndexedAccess(typeRef('PostFragment'))
+      expect(printType(node)).toBe('PostFragment[number]')
+    })
+  })
+
+  describe('arrayOf', () => {
+    it('emits T[]', () => {
+      expect(printType(arrayOf(typeRef('PostFragment')))).toBe('PostFragment[]')
+    })
+  })
+
+  describe('unionOrSingle', () => {
+    it('unwraps a single-element union to the element', () => {
+      expect(printType(unionOrSingle([typeRef('PostFragment')]))).toBe('PostFragment')
+    })
+
+    it('emits a union for multiple elements', () => {
+      expect(printType(unionOrSingle([typeRef('PostFragment'), typeRef('PageFragment')])))
+        .toBe('PostFragment | PageFragment')
+    })
+
+    it('throws on an empty list', () => {
+      expect(() => unionOrSingle([])).toThrow()
+    })
+  })
+
+  describe('full path composition', () => {
+    it('builds a connection item type', () => {
+      // Mirrors generate.ts for a connection query with inline fields, nodes=['posts']
+      let node = typeRef('PostsRootQuery') as Parameters<typeof nonNullable>[0]
+      node = indexedAccess(nonNullable(node), 'posts')
+      const final = numberIndexedAccess(indexedAccess(nonNullable(node), 'nodes'))
+      expect(printType(final)).toBe(
+        `NonNullable<NonNullable<PostsRootQuery>['posts']>['nodes'][number]`
+      )
+    })
+
+    it('builds a non-connection list type with fragments', () => {
+      const final = unionOrSingle([arrayOf(withImagePath(typeRef('PostFragment')))])
+      expect(printType(final)).toBe('WithImagePath<PostFragment>[]')
+    })
+
+    it('builds a connection singular fragment type', () => {
+      const final = unionOrSingle([
+        withImagePath(typeRef('PageFragment')),
+        withImagePath(typeRef('PostFragment'))
+      ])
+      expect(printType(final)).toBe('WithImagePath<PageFragment> | WithImagePath<PostFragment>')
+    })
+  })
+})

--- a/packages/core/test/validateGenerated.test.ts
+++ b/packages/core/test/validateGenerated.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { validateGeneratedPaths } from '../src/utils/validateGenerated'
+
+function writeOperationsFile(dir: string, content: string): string {
+  const path = join(dir, 'graphql-operations.d.ts')
+  writeFileSync(path, content, 'utf8')
+  return path
+}
+
+describe('validateGeneratedPaths', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'wpnuxt-validate-'))
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('returns skipped when the operations file does not exist', () => {
+    const result = validateGeneratedPaths(
+      ['PostsQueryVariables', 'PostFragment'],
+      join(tmpDir, 'nope.d.ts')
+    )
+    expect(result.skipped).toBe(true)
+    expect(result.dangling).toEqual([])
+  })
+
+  it('flags references not declared in the operations file', () => {
+    const path = writeOperationsFile(tmpDir, `
+      export interface PostsQueryVariables { limit?: number }
+      export type PostFragment = { id: string }
+    `)
+    const result = validateGeneratedPaths(
+      ['PostsQueryVariables', 'PostFragment', 'GhostFragment', 'RenamedRootQuery'],
+      path
+    )
+    expect(result.skipped).toBe(false)
+    expect(result.dangling).toEqual(['GhostFragment', 'RenamedRootQuery'])
+  })
+
+  it('returns an empty dangling list when every reference exists', () => {
+    const path = writeOperationsFile(tmpDir, `
+      export interface PostsRootQuery { posts?: unknown }
+      export interface PostsQueryVariables { first?: number }
+      export type PostFragment = { id: string }
+    `)
+    const result = validateGeneratedPaths(
+      ['PostsRootQuery', 'PostsQueryVariables', 'PostFragment'],
+      path
+    )
+    expect(result.skipped).toBe(false)
+    expect(result.dangling).toEqual([])
+  })
+
+  it('deduplicates repeated references', () => {
+    const path = writeOperationsFile(tmpDir, 'export type PostFragment = { id: string }')
+    const result = validateGeneratedPaths(
+      ['MissingFragment', 'MissingFragment', 'MissingFragment'],
+      path
+    )
+    expect(result.dangling).toEqual(['MissingFragment'])
+  })
+
+  it('recognizes symbols declared inside declare module blocks', () => {
+    const path = writeOperationsFile(tmpDir, `
+      declare module 'nuxt-graphql-middleware/generated-types' {
+        export interface PostsQueryVariables { first?: number }
+        export type PostFragment = { id: string }
+      }
+    `)
+    const result = validateGeneratedPaths(
+      ['PostsQueryVariables', 'PostFragment'],
+      path
+    )
+    expect(result.dangling).toEqual([])
+  })
+
+  it('recognizes const declarations', () => {
+    const path = writeOperationsFile(tmpDir, `
+      export const PostsDocument = {} as const
+    `)
+    const result = validateGeneratedPaths(
+      ['PostsDocument', 'MissingDocument'],
+      path
+    )
+    expect(result.dangling).toEqual(['MissingDocument'])
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -206,6 +206,9 @@ importers:
       scule:
         specifier: ^1.3.0
         version: 1.3.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
     devDependencies:
       '@nuxt/devtools':
         specifier: ^3.2.3


### PR DESCRIPTION
Closes #264.

## Summary

Replaces string-template type-path generation in `generate.ts` with `ts.factory`-emitted AST nodes, and adds a build-time validator that warns when generated composables reference types not declared in `.nuxt/graphql-operations.d.ts`.

## Motivation

Before this PR, `getFragmentType()` built TypeScript paths like `NonNullable<PostsRootQuery>['posts']['nodes'][number]` via string concatenation. If the schema drifted — a fragment deleted, a root query renamed, a query removed — the generator silently produced a dangling path. The symptom surfaced later as a cryptic _"Property 'X' does not exist on type..."_ error in user code.

Two improvements:

1. **AST emission** — the generator's shape is now machine-checkable inside the module. Typos or shape mistakes are a TypeScript compile error here, not a surprise in user code.
2. **Schema-drift validation** — on every build, the generated type references are diffed against the declared identifiers in `graphql-operations.d.ts`. Dangling references are surfaced as warnings in the module's own log output, long before the user sees a TS error.

## What's in the diff

| File | Change |
|---|---|
| `src/utils/typegen.ts` (new) | `ts.factory` wrappers: `typeRef`, `nonNullable`, `withImagePath`, `indexedAccess`, `numberIndexedAccess`, `arrayOf`, `unionOrSingle`, `printType`. |
| `src/generate.ts` | `getFragmentType` now composes `ts.TypeNode`s via `buildFragmentTypeNode` and prints once. Output is text-equivalent to before (single-quote keys preserved via `createStringLiteral(text, /* isSingleQuote */ true)`). `ctx.referencedTypes` now populated for the validator. |
| `src/utils/validateGenerated.ts` (new) | Parses `graphql-operations.d.ts` via `ts.createSourceFile`, collects declared identifiers (type aliases, interfaces, classes, consts, and declarations inside `declare module {}` blocks), returns dangling references. |
| `src/module.ts` | New `build:before` hook runs the validator; warns on dangling refs, skips silently if the operations file doesn't exist yet (first-ever build). |
| `src/types/queries.ts` | `WPNuxtContext.referencedTypes?: string[]` added. |
| `package.json` | `typescript@^5.9.3` added as a direct runtime dep — the generator runs at module setup in user projects. |

## Scope

Validates **top-level identifiers only** (fragment names, root-query names, query-variables, mutation names, mutation-variables). Catches:
- Deleted or renamed fragments
- Removed queries / mutations
- Renamed top-level query names

Does **not** catch deep-path drift (e.g. a renamed field inside a query like `nodes` → `items`). That would require the full TypeScript type checker, which is disproportionate for this pass.

## Public API impact

None. Generated `.d.ts` output is text-equivalent (same tokens, same quote style). Existing `generate.test.ts` string assertions pass unchanged.

## Test plan

- [x] `pnpm run check` passes locally (275/275 core tests — 20 new tests across `typegen.test.ts` and `validateGenerated.test.ts`, all 4 playgrounds build clean).
- [x] `typegen.test.ts`: snapshot the printer output for each helper and a full connection-item path composition.
- [x] `validateGenerated.test.ts`: fixture-based with a temp dir; covers skip-when-missing, dangling detection, deduplication, `declare module` walking, and `const` declarations.
- [ ] Manual drift smoke test: delete `packages/core/src/runtime/queries/fragments/Post.fragment.gql`, re-run `pnpm run dev:prepare` → validator warns about `PostFragment` not declared.