### PR TITLE
feat(core): auto-generate fragments + queries for Custom Post Types

### DIFF
--- a/packages/core/src/module.ts
+++ b/packages/core/src/module.ts
@@ -106,38 +106,29 @@ export default defineNuxtModule<WPNuxtConfig>({
     })
     logger.debug('Registered WPNuxt layer for graphqlMiddleware options auto-discovery')
 
-    // Validate WordPress endpoint and download schema if needed.
-    // Runs before mergeQueries so CPT auto-generation has schema.graphql to parse.
+    // Validate WordPress endpoint and (re)download schema. Runs before
+    // mergeQueries so CPT auto-generation reads the freshest schema — a
+    // cached schema would miss newly-registered CPTs. If the network call
+    // fails and we already have a local schema.graphql, fall back to it
+    // so a momentary WP outage doesn't break the build. Users who want to
+    // skip the network hop entirely (CI, offline dev) set
+    // `downloadSchema: false` and commit schema.graphql.
     const schemaPath = join(nuxt.options.rootDir, 'schema.graphql')
     const schemaExists = existsSync(schemaPath)
 
     if (wpNuxtConfig.downloadSchema) {
-      if (!schemaExists) {
-        // Schema doesn't exist - must download it (blocking, required for app to work)
-        logger.debug(`Downloading schema from: ${wpNuxtConfig.wordpressUrl}${wpNuxtConfig.graphqlEndpoint}`)
+      logger.debug(`Downloading schema from: ${wpNuxtConfig.wordpressUrl}${wpNuxtConfig.graphqlEndpoint}`)
+      try {
         await validateWordPressEndpoint(
           wpNuxtConfig.wordpressUrl!,
           wpNuxtConfig.graphqlEndpoint,
           { schemaPath, authToken: wpNuxtConfig.schemaAuthToken }
         )
         logger.debug('Schema downloaded successfully')
-      } else {
-        // Schema exists - defer validation to ready hook (non-blocking)
-        nuxt.hook('ready', async () => {
-          try {
-            await validateWordPressEndpoint(
-              wpNuxtConfig.wordpressUrl!,
-              wpNuxtConfig.graphqlEndpoint,
-              { authToken: wpNuxtConfig.schemaAuthToken }
-            )
-            logger.debug('WordPress endpoint validation passed')
-          } catch (error) {
-            // Log warning but don't block app - schema already exists
-            const message = error instanceof Error ? error.message : String(error)
-            logger.warn(`WordPress endpoint validation failed: ${message.split('\n')[0]}`)
-            logger.warn('App will continue with existing schema.graphql file')
-          }
-        })
+      } catch (error) {
+        if (!schemaExists) throw error
+        const message = error instanceof Error ? error.message : String(error)
+        logger.warn(`Schema refresh failed, using cached schema.graphql: ${message.split('\n')[0]}`)
       }
     }
 

--- a/packages/core/src/module.ts
+++ b/packages/core/src/module.ts
@@ -57,6 +57,11 @@ export default defineNuxtModule<WPNuxtConfig>({
       enabled: true,
       maxAge: 60 * 5, // 5 minutes
       swr: true
+    },
+    cpt: {
+      enabled: true,
+      exclude: [],
+      include: []
     }
   },
   async setup(options, nuxt) {
@@ -83,8 +88,6 @@ export default defineNuxtModule<WPNuxtConfig>({
     // This ensures both server-side and client-side URLs use trailing slashes
     configureTrailingSlash(nuxt, logger)
 
-    const mergedQueriesFolder = await mergeQueries(nuxt, wpNuxtConfig, resolver)
-
     // Register WPNuxt as a layer so nuxt-graphql-middleware 5.4+ auto-discovers
     // the default server/client options from the package directory.
     // Appended to _layers = lower priority than main app, so user files win.
@@ -102,7 +105,8 @@ export default defineNuxtModule<WPNuxtConfig>({
     })
     logger.debug('Registered WPNuxt layer for graphqlMiddleware options auto-discovery')
 
-    // Validate WordPress endpoint and download schema if needed
+    // Validate WordPress endpoint and download schema if needed.
+    // Runs before mergeQueries so CPT auto-generation has schema.graphql to parse.
     const schemaPath = join(nuxt.options.rootDir, 'schema.graphql')
     const schemaExists = existsSync(schemaPath)
 
@@ -135,6 +139,8 @@ export default defineNuxtModule<WPNuxtConfig>({
         })
       }
     }
+
+    const mergedQueriesFolder = await mergeQueries(nuxt, wpNuxtConfig, resolver, schemaPath)
 
     await registerModules(nuxt, resolver, wpNuxtConfig, mergedQueriesFolder)
 

--- a/packages/core/src/runtime/util/content.ts
+++ b/packages/core/src/runtime/util/content.ts
@@ -46,7 +46,17 @@ export const transformData = <T>(data: unknown, nodes: string[], fixImagePaths: 
   if (fixImagePaths && transformedData) {
     if (Array.isArray(transformedData)) {
       transformedData.forEach(addRelativePath)
-    } else {
+    } else if (typeof transformedData === 'object') {
+      // When the extraction path stops at a WPGraphQL connection object
+      // (shape `{ nodes: [...], pageInfo: {...} }`) — common with
+      // auto-generated connection queries — iterate the inner `nodes`
+      // array so each item still receives a `relativePath`. Also apply
+      // to the object itself in case it is a single-fetch result with a
+      // `featuredImage` at this level.
+      const maybeNodes = (transformedData as { nodes?: unknown }).nodes
+      if (Array.isArray(maybeNodes)) {
+        maybeNodes.forEach(addRelativePath)
+      }
       addRelativePath(transformedData)
     }
   }

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -139,4 +139,43 @@ export interface WPNuxtConfig {
      */
     revalidateSecret?: string
   }
+
+  /**
+   * Auto-generation of fragments + queries for Custom Post Types.
+   *
+   * WPNuxt parses the downloaded `schema.graphql` at build time, finds every
+   * object type implementing `ContentNode`, and emits a base fragment plus
+   * `Listing`, `ByUri`, and `BySlug` queries for each discovered CPT. Built-in
+   * types (Post, Page, MediaItem, Revision, Comment) are excluded because
+   * they already have default queries.
+   *
+   * Generated files land in `.queries/` and can be fully overridden by
+   * dropping a file with the same name in `extend/queries/fragments/`
+   * (for fragments) or `extend/queries/` (for queries).
+   */
+  cpt?: {
+    /**
+     * Enable CPT auto-generation.
+     *
+     * @default true
+     */
+    enabled?: boolean
+
+    /**
+     * Type names to skip in addition to the built-in exclusions.
+     *
+     * @example ['DraftPost', 'InternalNote']
+     */
+    exclude?: string[]
+
+    /**
+     * If set, only these type names will be auto-generated.
+     *
+     * Useful when you want fine-grained control over which CPTs get
+     * auto-generated output. Built-in exclusions still apply.
+     *
+     * @example ['Event', 'Artist']
+     */
+    include?: string[]
+  }
 }

--- a/packages/core/src/utils/cptDiscovery.ts
+++ b/packages/core/src/utils/cptDiscovery.ts
@@ -1,0 +1,161 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { parse } from 'graphql'
+import type {
+  DocumentNode,
+  EnumTypeDefinitionNode,
+  FieldDefinitionNode,
+  ObjectTypeDefinitionNode,
+  TypeNode
+} from 'graphql'
+
+/**
+ * Information about a Custom Post Type discovered in the WPGraphQL schema,
+ * enough to auto-generate a base fragment and the standard list/byUri/bySlug
+ * queries for it.
+ */
+export interface DiscoveredCpt {
+  /** GraphQL object type name, e.g. `Event`. */
+  typeName: string
+  /** RootQuery field for single-item fetch, e.g. `event`. */
+  singleField: string
+  /** RootQuery field for the connection, e.g. `events`. */
+  connectionField: string
+  /** Name of the `*IdType` enum used by `singleField`, e.g. `EventIdType`. */
+  idTypeEnum?: string
+  /** IdType enum values the CPT supports (e.g. `URI`, `SLUG`, `DATABASE_ID`). */
+  supportedIdTypes: Set<string>
+  /** The set of GraphQL interfaces the type implements (e.g. `ContentNode`, `NodeWithTitle`). */
+  interfaces: Set<string>
+  /** Whether the type declares specific scalar fields directly (title, slug, etc.). */
+  hasField: Record<string, boolean>
+}
+
+export interface CptDiscoveryOptions {
+  /** Type names to exclude (in addition to the built-in exclusions). */
+  exclude?: string[]
+  /** If set, only these type names will be returned. */
+  include?: string[]
+}
+
+/**
+ * Built-in WPGraphQL types that implement `ContentNode` but already have
+ * default WPNuxt fragments/queries or are not user-facing CPTs.
+ */
+export const DEFAULT_CPT_EXCLUSIONS: readonly string[] = [
+  'Post',
+  'Page',
+  'MediaItem',
+  'Revision',
+  'Comment',
+  'ActionMonitorAction'
+]
+
+/**
+ * Parse the WPGraphQL schema at `schemaPath` and return every Custom Post
+ * Type that should receive auto-generated fragments and queries.
+ *
+ * Returns `[]` if the schema file does not exist (first-ever build) or is
+ * malformed — the caller treats this as "no CPTs to generate" rather than
+ * an error, so a missing schema does not block module setup.
+ */
+export function discoverCpts(schemaPath: string, options: CptDiscoveryOptions = {}): DiscoveredCpt[] {
+  if (!existsSync(schemaPath)) return []
+
+  let ast: DocumentNode
+  try {
+    ast = parse(readFileSync(schemaPath, 'utf8'), { noLocation: true })
+  } catch {
+    return []
+  }
+
+  const typesByName = new Map<string, ObjectTypeDefinitionNode>()
+  const enumsByName = new Map<string, EnumTypeDefinitionNode>()
+  for (const def of ast.definitions) {
+    if (def.kind === 'ObjectTypeDefinition') typesByName.set(def.name.value, def)
+    else if (def.kind === 'EnumTypeDefinition') enumsByName.set(def.name.value, def)
+  }
+
+  const rootQuery = typesByName.get('RootQuery')
+  if (!rootQuery?.fields) return []
+
+  // Map type name → its single-fetch and connection fields on RootQuery.
+  // - Single: field returns the type directly AND has an `idType` argument.
+  // - Connection: field returns `RootQueryTo${TypeName}Connection` AND has cursor args.
+  const fieldsByType = new Map<string, { single?: string, connection?: string, idTypeEnum?: string }>()
+  for (const field of rootQuery.fields) {
+    const returnType = unwrapNamedType(field.type)
+    if (!returnType) continue
+
+    const hasIdType = field.arguments?.some(a => a.name.value === 'idType')
+    if (typesByName.has(returnType) && hasIdType) {
+      const idTypeArg = field.arguments?.find(a => a.name.value === 'idType')
+      const idTypeEnum = idTypeArg ? unwrapNamedType(idTypeArg.type) : undefined
+      const entry = fieldsByType.get(returnType) ?? {}
+      entry.single = field.name.value
+      entry.idTypeEnum = idTypeEnum
+      fieldsByType.set(returnType, entry)
+      continue
+    }
+
+    const connMatch = /^RootQueryTo(\w+)Connection$/.exec(returnType)
+    const hasCursorArgs = field.arguments?.some(a => a.name.value === 'first')
+      && field.arguments?.some(a => a.name.value === 'after')
+    if (connMatch && hasCursorArgs) {
+      const typeName = connMatch[1]!
+      const entry = fieldsByType.get(typeName) ?? {}
+      entry.connection = field.name.value
+      fieldsByType.set(typeName, entry)
+    }
+  }
+
+  const excludeSet = new Set<string>([...DEFAULT_CPT_EXCLUSIONS, ...(options.exclude ?? [])])
+  const includeSet = options.include?.length ? new Set(options.include) : undefined
+
+  const result: DiscoveredCpt[] = []
+  for (const [typeName, node] of typesByName) {
+    if (!typeImplements(node, 'ContentNode')) continue
+    if (excludeSet.has(typeName)) continue
+    if (includeSet && !includeSet.has(typeName)) continue
+
+    const queryFields = fieldsByType.get(typeName)
+    if (!queryFields?.single || !queryFields.connection) continue
+
+    const supportedIdTypes = new Set<string>()
+    if (queryFields.idTypeEnum) {
+      const enumDef = enumsByName.get(queryFields.idTypeEnum)
+      enumDef?.values?.forEach(v => supportedIdTypes.add(v.name.value))
+    }
+
+    result.push({
+      typeName,
+      singleField: queryFields.single,
+      connectionField: queryFields.connection,
+      idTypeEnum: queryFields.idTypeEnum,
+      supportedIdTypes,
+      interfaces: new Set((node.interfaces ?? []).map(i => i.name.value)),
+      hasField: collectScalarFieldFlags(node, ['title', 'slug', 'uri', 'date'])
+    })
+  }
+
+  return result.sort((a, b) => a.typeName.localeCompare(b.typeName))
+}
+
+function unwrapNamedType(type: TypeNode): string | undefined {
+  let current: TypeNode | undefined = type
+  while (current) {
+    if (current.kind === 'NamedType') return current.name.value
+    current = (current as { type?: TypeNode }).type
+  }
+  return undefined
+}
+
+function typeImplements(node: ObjectTypeDefinitionNode, interfaceName: string): boolean {
+  return node.interfaces?.some(i => i.name.value === interfaceName) ?? false
+}
+
+function collectScalarFieldFlags(node: ObjectTypeDefinitionNode, fieldNames: string[]): Record<string, boolean> {
+  const flags: Record<string, boolean> = {}
+  const declared = new Set<string>((node.fields ?? []).map((f: FieldDefinitionNode) => f.name.value))
+  for (const name of fieldNames) flags[name] = declared.has(name)
+  return flags
+}

--- a/packages/core/src/utils/endpointValidation.ts
+++ b/packages/core/src/utils/endpointValidation.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { readFileSync, writeFileSync } from 'node:fs'
 import { execSync } from 'node:child_process'
 import { parse, visit, print } from 'graphql'
 import type { InterfaceTypeDefinitionNode, ObjectTypeDefinitionNode } from 'graphql'
@@ -90,8 +90,11 @@ Make sure WPGraphQL plugin is installed and activated on your WordPress site.`
     // If it's missing, the WPGraphQL version is too old for WPNuxt v2
     await checkWPGraphQLVersion(fullUrl, headers)
 
-    // If schemaPath is provided and schema doesn't exist, download it using get-graphql-schema
-    if (options.schemaPath && !existsSync(options.schemaPath)) {
+    // If schemaPath is provided, (re)download it using get-graphql-schema.
+    // Re-downloading each time keeps the file fresh so CPT discovery and
+    // codegen see newly-registered WordPress types; callers that want a
+    // cached schema should skip passing schemaPath.
+    if (options.schemaPath) {
       try {
         const authFlag = options.authToken ? ` -h "Authorization=Bearer ${options.authToken}"` : ''
         execSync(`npx get-graphql-schema "${fullUrl}"${authFlag} > "${options.schemaPath}"`, {

--- a/packages/core/src/utils/generateCpt.ts
+++ b/packages/core/src/utils/generateCpt.ts
@@ -1,0 +1,118 @@
+import { existsSync } from 'node:fs'
+import { mkdir, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { upperFirst } from 'scule'
+import type { DiscoveredCpt } from './cptDiscovery'
+
+export interface CptArtifactResult {
+  /** The CPT this was generated for. */
+  cpt: DiscoveredCpt
+  /** True if a fragment file was written (i.e. no override existed). */
+  wroteFragment: boolean
+  /** True if a query file was written (i.e. no override existed). */
+  wroteQueries: boolean
+}
+
+/**
+ * Write the auto-generated fragment + query GQL files for one CPT into the
+ * merged queries output folder. Existing files are never overwritten — this
+ * runs before `extend/queries/` is copied over, and before that the defaults
+ * already populated the folder, so every file-exists check represents an
+ * intentional override.
+ */
+export async function writeCptArtifacts(cpt: DiscoveredCpt, outputPath: string): Promise<CptArtifactResult> {
+  const fragmentsDir = join(outputPath, 'fragments')
+  const fragmentPath = join(fragmentsDir, `${cpt.typeName}.fragment.gql`)
+  // Name the query file after the plural (e.g. `Events.gql`) to mirror the
+  // built-in `Posts.gql` convention so a user's extend-folder override
+  // cleanly replaces everything the generator wrote.
+  const queryPath = join(outputPath, `${upperFirst(cpt.connectionField)}.gql`)
+
+  const wroteFragment = !existsSync(fragmentPath)
+  const wroteQueries = !existsSync(queryPath)
+
+  if (wroteFragment) {
+    await mkdir(fragmentsDir, { recursive: true })
+    await writeFile(fragmentPath, buildCptFragment(cpt), 'utf-8')
+  }
+
+  if (wroteQueries) {
+    await writeFile(queryPath, buildCptQueries(cpt), 'utf-8')
+  }
+
+  return { cpt, wroteFragment, wroteQueries }
+}
+
+/**
+ * Emit the base fragment for a CPT. Spreads only interfaces the type
+ * actually implements — a CPT registered without `excerpt` support does not
+ * implement `NodeWithExcerpt`, and pulling that interface's fields would
+ * produce an invalid query.
+ */
+export function buildCptFragment(cpt: DiscoveredCpt): string {
+  const lines: string[] = [`fragment ${cpt.typeName} on ${cpt.typeName} {`]
+  lines.push('  ...ContentNode')
+  if (cpt.interfaces.has('NodeWithExcerpt')) lines.push('  ...NodeWithExcerpt')
+  if (cpt.interfaces.has('NodeWithContentEditor')) lines.push('  ...NodeWithContentEditor')
+  if (cpt.interfaces.has('NodeWithFeaturedImage')) lines.push('  ...NodeWithFeaturedImage')
+  // `title` is not covered by any default fragment (there is no
+  // NodeWithTitle.fragment.gql shipped), so include it as a direct field
+  // when the type declares it.
+  if (cpt.hasField.title) lines.push('  title')
+  lines.push('}')
+  lines.push('')
+  return lines.join('\n')
+}
+
+/**
+ * Emit the standard list + single-fetch queries for a CPT. Generated:
+ * - `${Plural}` — cursor-based connection query with `pageInfo` for `loadMore()`.
+ * - `${Type}ByUri` — single-fetch by URI, only if the CPT's idType enum includes `URI`.
+ * - `${Type}BySlug` — single-fetch by slug, only if the idType enum includes `SLUG`.
+ */
+export function buildCptQueries(cpt: DiscoveredCpt): string {
+  const { typeName, singleField, connectionField, supportedIdTypes } = cpt
+  const listQueryName = upperFirst(connectionField)
+  const queries: string[] = []
+
+  queries.push(
+    `query ${listQueryName}($first: Int = 20, $after: String) {`,
+    `  ${connectionField}(first: $first, after: $after) {`,
+    `    nodes {`,
+    `      ...${typeName}`,
+    `    }`,
+    `    pageInfo {`,
+    `      hasNextPage`,
+    `      hasPreviousPage`,
+    `      startCursor`,
+    `      endCursor`,
+    `    }`,
+    `  }`,
+    `}`,
+    ''
+  )
+
+  if (supportedIdTypes.has('URI')) {
+    queries.push(
+      `query ${typeName}ByUri($uri: ID!) {`,
+      `  ${singleField}(id: $uri, idType: URI) {`,
+      `    ...${typeName}`,
+      `  }`,
+      `}`,
+      ''
+    )
+  }
+
+  if (supportedIdTypes.has('SLUG')) {
+    queries.push(
+      `query ${typeName}BySlug($slug: ID!) {`,
+      `  ${singleField}(id: $slug, idType: SLUG) {`,
+      `    ...${typeName}`,
+      `  }`,
+      `}`,
+      ''
+    )
+  }
+
+  return queries.join('\n')
+}

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -6,6 +6,8 @@ import type { Resolver } from '@nuxt/kit'
 import type { ConsolaInstance } from 'consola'
 import type { Nuxt } from 'nuxt/schema'
 import type { WPNuxtConfig } from '../types/config'
+import { discoverCpts } from './cptDiscovery'
+import { writeCptArtifacts } from './generateCpt'
 
 // Re-export error utilities
 export { createModuleError, formatErrorMessage, type WPNuxtModule } from './errors'
@@ -77,7 +79,12 @@ export function getLogger(): ConsolaInstance {
   return loggerInstance!
 }
 
-export async function mergeQueries(nuxt: Nuxt, wpNuxtConfig: WPNuxtConfig, resolver: Resolver) {
+export async function mergeQueries(
+  nuxt: Nuxt,
+  wpNuxtConfig: WPNuxtConfig,
+  resolver: Resolver,
+  schemaPath?: string
+) {
   const logger = getLogger()
 
   // Cache base directory
@@ -92,6 +99,24 @@ export async function mergeQueries(nuxt: Nuxt, wpNuxtConfig: WPNuxtConfig, resol
 
   // Copy default queries
   cpSync(defaultQueriesPath, queryOutputPath, { recursive: true })
+
+  // Auto-generate fragments + queries for Custom Post Types discovered in
+  // the downloaded schema. Runs BEFORE the user override copy so users can
+  // still override any generated file by dropping one in extend/queries/.
+  const cptSpreads: ContentTypeFragment[] = []
+  if (schemaPath && wpNuxtConfig.cpt?.enabled !== false) {
+    const cpts = discoverCpts(schemaPath, {
+      exclude: wpNuxtConfig.cpt?.exclude,
+      include: wpNuxtConfig.cpt?.include
+    })
+    for (const cpt of cpts) {
+      await writeCptArtifacts(cpt, queryOutputPath)
+      cptSpreads.push({ name: cpt.typeName, type: cpt.typeName })
+    }
+    if (cpts.length) {
+      logger.debug(`Auto-generated fragments + queries for CPTs: ${cpts.map(c => c.typeName).join(', ')}`)
+    }
+  }
 
   // Detect conflicts between default and user queries
   const conflicts = findConflicts(userQueryPath, queryOutputPath)
@@ -108,8 +133,10 @@ export async function mergeQueries(nuxt: Nuxt, wpNuxtConfig: WPNuxtConfig, resol
     copyGraphqlFiles(userQueryPath, queryOutputPath)
   }
 
-  // Auto-add custom content type fragments to NodeByUri query
-  await addCustomFragmentsToNodeQuery(queryOutputPath, userQueryPath, logger)
+  // Auto-add custom content type fragments to NodeByUri query. The CPT
+  // spreads are merged with any content-type fragments the user may have
+  // added manually in extend/queries/fragments/.
+  await addCustomFragmentsToNodeQuery(queryOutputPath, userQueryPath, logger, cptSpreads)
 
   logger.debug('Merged queries folder:', queryOutputPath)
   return queryOutputPath
@@ -117,6 +144,11 @@ export async function mergeQueries(nuxt: Nuxt, wpNuxtConfig: WPNuxtConfig, resol
 
 /** Regex to extract fragment name and type condition from a .gql file */
 const FRAGMENT_DEF_PATTERN = /fragment\s+(\w+)\s+on\s+(\w+)/
+
+export interface ContentTypeFragment {
+  name: string
+  type: string
+}
 
 /**
  * Scans the user's extend/queries/fragments/ directory for custom content type
@@ -126,28 +158,38 @@ const FRAGMENT_DEF_PATTERN = /fragment\s+(\w+)\s+on\s+(\w+)/
  *
  * A fragment is considered a content type fragment when its name matches its
  * type condition (e.g., `fragment Event on Event`).
+ *
+ * @param preDiscovered Spreads already known from auto-generated CPT fragments.
+ *   Merged with anything scanned from the user folder and deduplicated by type.
  */
-export async function addCustomFragmentsToNodeQuery(queryOutputPath: string, userQueryPath: string, logger: ConsolaInstance): Promise<void> {
+export async function addCustomFragmentsToNodeQuery(
+  queryOutputPath: string,
+  userQueryPath: string,
+  logger: ConsolaInstance,
+  preDiscovered: ContentTypeFragment[] = []
+): Promise<void> {
+  const byType = new Map<string, ContentTypeFragment>()
+  for (const f of preDiscovered) byType.set(f.type, f)
+
   const userFragmentsDir = join(userQueryPath, 'fragments')
-  if (!existsSync(userFragmentsDir)) return
+  if (existsSync(userFragmentsDir)) {
+    for (const file of readdirSync(userFragmentsDir)) {
+      if (!file.endsWith('.gql') && !file.endsWith('.graphql')) continue
 
-  const customFragments: { name: string, type: string }[] = []
+      const content = await fsp.readFile(join(userFragmentsDir, file), 'utf-8')
+      const match = content.match(FRAGMENT_DEF_PATTERN)
+      if (!match) continue
 
-  for (const file of readdirSync(userFragmentsDir)) {
-    if (!file.endsWith('.gql') && !file.endsWith('.graphql')) continue
-
-    const content = await fsp.readFile(join(userFragmentsDir, file), 'utf-8')
-    const match = content.match(FRAGMENT_DEF_PATTERN)
-    if (!match) continue
-
-    const name = match[1]
-    const type = match[2]
-    // Content type fragments have name === type (e.g., fragment Event on Event)
-    if (name && type && name === type) {
-      customFragments.push({ name, type })
+      const name = match[1]
+      const type = match[2]
+      // Content type fragments have name === type (e.g., fragment Event on Event)
+      if (name && type && name === type) {
+        byType.set(type, { name, type })
+      }
     }
   }
 
+  const customFragments = [...byType.values()]
   if (customFragments.length === 0) return
 
   // Add custom fragment spreads to Node.gql

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -159,6 +159,9 @@ export interface ContentTypeFragment {
  * A fragment is considered a content type fragment when its name matches its
  * type condition (e.g., `fragment Event on Event`).
  *
+ * @param queryOutputPath Merged queries folder where Node.gql lives.
+ * @param userQueryPath User extend/queries folder scanned for content-type fragments.
+ * @param logger Module logger.
  * @param preDiscovered Spreads already known from auto-generated CPT fragments.
  *   Merged with anything scanned from the user folder and deduplicated by type.
  */

--- a/packages/core/test/content.test.ts
+++ b/packages/core/test/content.test.ts
@@ -78,6 +78,25 @@ describe('content utilities', () => {
       expect(result.featuredImage.node.relativePath).toBe('/wp-content/uploads/2024/image.jpg')
     })
 
+    it('should add relativePath to each node in a connection object (path stops at connection)', () => {
+      // Mirrors the shape `useWPConnection` receives: the extraction path
+      // stops at `['sponsors']`, so transformData sees the connection
+      // wrapper object with a `nodes` array. Each node still needs its
+      // relativePath populated.
+      const data = {
+        sponsors: {
+          nodes: [
+            { id: '1', featuredImage: { node: { sourceUrl: 'https://example.com/wp-content/uploads/a.png' } } },
+            { id: '2', featuredImage: { node: { sourceUrl: 'https://example.com/wp-content/uploads/b.png' } } }
+          ],
+          pageInfo: { hasNextPage: false }
+        }
+      }
+      const result = transformData<{ nodes: Array<{ featuredImage: { node: { relativePath?: string } } }> }>(data, ['sponsors'], true)
+      expect(result.nodes[0]!.featuredImage.node.relativePath).toBe('/wp-content/uploads/a.png')
+      expect(result.nodes[1]!.featuredImage.node.relativePath).toBe('/wp-content/uploads/b.png')
+    })
+
     it('should preserve original sourceUrl when adding relativePath', () => {
       const data = {
         post: {

--- a/packages/core/test/cptDiscovery.test.ts
+++ b/packages/core/test/cptDiscovery.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { DEFAULT_CPT_EXCLUSIONS, discoverCpts } from '../src/utils/cptDiscovery'
+
+/**
+ * Minimal schema fixture that exercises the discovery logic:
+ * - `Event` (user CPT) — has single + connection RootQuery fields + idType enum with URI/SLUG
+ * - `Post` (built-in) — should be auto-excluded
+ * - `Venue` (user CPT) — no connection field → should be skipped
+ * - `NotAContentNode` — does not implement ContentNode → skipped
+ */
+const SCHEMA_SDL = `
+interface ContentNode {
+  id: ID!
+}
+
+type Event implements ContentNode & NodeWithTitle & NodeWithExcerpt & NodeWithFeaturedImage {
+  id: ID!
+  title: String
+  slug: String
+  uri: String
+  date: String
+}
+
+type Post implements ContentNode & NodeWithTitle {
+  id: ID!
+  title: String
+}
+
+type Venue implements ContentNode {
+  id: ID!
+  title: String
+}
+
+type NotAContentNode {
+  id: ID!
+}
+
+enum EventIdType {
+  DATABASE_ID
+  ID
+  SLUG
+  URI
+}
+
+enum PostIdType {
+  DATABASE_ID
+  ID
+  SLUG
+  URI
+}
+
+enum VenueIdType {
+  DATABASE_ID
+  ID
+}
+
+type RootQueryToEventConnection {
+  nodes: [Event!]!
+}
+
+type RootQueryToPostConnection {
+  nodes: [Post!]!
+}
+
+type RootQuery {
+  event(id: ID!, idType: EventIdType): Event
+  events(first: Int, after: String): RootQueryToEventConnection
+  post(id: ID!, idType: PostIdType): Post
+  posts(first: Int, after: String): RootQueryToPostConnection
+  venue(id: ID!, idType: VenueIdType): Venue
+}
+`
+
+describe('discoverCpts', () => {
+  let tmpDir: string
+  let schemaPath: string
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'wpnuxt-discover-'))
+    schemaPath = join(tmpDir, 'schema.graphql')
+    writeFileSync(schemaPath, SCHEMA_SDL, 'utf8')
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('returns [] when the schema file is missing', () => {
+    expect(discoverCpts(join(tmpDir, 'missing.graphql'))).toEqual([])
+  })
+
+  it('returns [] when the schema is malformed', () => {
+    writeFileSync(schemaPath, 'this is not graphql', 'utf8')
+    expect(discoverCpts(schemaPath)).toEqual([])
+  })
+
+  it('finds Custom Post Types that implement ContentNode with matching RootQuery fields', () => {
+    const cpts = discoverCpts(schemaPath)
+    expect(cpts.map(c => c.typeName)).toEqual(['Event'])
+  })
+
+  it('extracts RootQuery field names and idType metadata', () => {
+    const [event] = discoverCpts(schemaPath)
+    expect(event).toBeDefined()
+    expect(event!.singleField).toBe('event')
+    expect(event!.connectionField).toBe('events')
+    expect(event!.idTypeEnum).toBe('EventIdType')
+    expect(event!.supportedIdTypes).toEqual(new Set(['DATABASE_ID', 'ID', 'SLUG', 'URI']))
+  })
+
+  it('records the interfaces each CPT implements', () => {
+    const [event] = discoverCpts(schemaPath)
+    expect(event!.interfaces.has('ContentNode')).toBe(true)
+    expect(event!.interfaces.has('NodeWithTitle')).toBe(true)
+    expect(event!.interfaces.has('NodeWithExcerpt')).toBe(true)
+    expect(event!.interfaces.has('NodeWithFeaturedImage')).toBe(true)
+    expect(event!.interfaces.has('NodeWithContentEditor')).toBe(false)
+  })
+
+  it('records which scalar fields the type declares directly', () => {
+    const [event] = discoverCpts(schemaPath)
+    expect(event!.hasField.title).toBe(true)
+    expect(event!.hasField.slug).toBe(true)
+    expect(event!.hasField.uri).toBe(true)
+    expect(event!.hasField.date).toBe(true)
+  })
+
+  it('excludes built-in types like Post by default', () => {
+    const names = discoverCpts(schemaPath).map(c => c.typeName)
+    for (const excluded of DEFAULT_CPT_EXCLUSIONS) {
+      expect(names).not.toContain(excluded)
+    }
+  })
+
+  it('skips types without both single + connection RootQuery fields', () => {
+    // Venue has a single-fetch field but no connection
+    const names = discoverCpts(schemaPath).map(c => c.typeName)
+    expect(names).not.toContain('Venue')
+  })
+
+  it('respects the exclude option', () => {
+    const cpts = discoverCpts(schemaPath, { exclude: ['Event'] })
+    expect(cpts).toEqual([])
+  })
+
+  it('respects the include option (allowlist)', () => {
+    const cpts = discoverCpts(schemaPath, { include: ['Artist'] })
+    // Event present but not in include list
+    expect(cpts.map(c => c.typeName)).toEqual([])
+  })
+})

--- a/packages/core/test/generateCpt.test.ts
+++ b/packages/core/test/generateCpt.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, existsSync, writeFileSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { buildCptFragment, buildCptQueries, writeCptArtifacts } from '../src/utils/generateCpt'
+import type { DiscoveredCpt } from '../src/utils/cptDiscovery'
+
+const FULL_EVENT_CPT: DiscoveredCpt = {
+  typeName: 'Event',
+  singleField: 'event',
+  connectionField: 'events',
+  idTypeEnum: 'EventIdType',
+  supportedIdTypes: new Set(['DATABASE_ID', 'ID', 'SLUG', 'URI']),
+  interfaces: new Set([
+    'ContentNode',
+    'NodeWithTitle',
+    'NodeWithExcerpt',
+    'NodeWithContentEditor',
+    'NodeWithFeaturedImage'
+  ]),
+  hasField: { title: true, slug: true, uri: true, date: true }
+}
+
+describe('buildCptFragment', () => {
+  it('includes ContentNode + every NodeWith* spread the type implements', () => {
+    const fragment = buildCptFragment(FULL_EVENT_CPT)
+    expect(fragment).toContain('fragment Event on Event {')
+    expect(fragment).toContain('  ...ContentNode')
+    expect(fragment).toContain('  ...NodeWithExcerpt')
+    expect(fragment).toContain('  ...NodeWithContentEditor')
+    expect(fragment).toContain('  ...NodeWithFeaturedImage')
+    expect(fragment).toContain('  title')
+  })
+
+  it('omits spreads for interfaces the type does not implement', () => {
+    const minimal: DiscoveredCpt = {
+      ...FULL_EVENT_CPT,
+      interfaces: new Set(['ContentNode']),
+      hasField: { title: false, slug: true, uri: true, date: true }
+    }
+    const fragment = buildCptFragment(minimal)
+    expect(fragment).toContain('  ...ContentNode')
+    expect(fragment).not.toContain('NodeWithExcerpt')
+    expect(fragment).not.toContain('NodeWithContentEditor')
+    expect(fragment).not.toContain('NodeWithFeaturedImage')
+    expect(fragment).not.toContain('  title')
+  })
+})
+
+describe('buildCptQueries', () => {
+  it('emits a connection query named after the plural field', () => {
+    const q = buildCptQueries(FULL_EVENT_CPT)
+    expect(q).toContain('query Events($first: Int = 20, $after: String) {')
+    expect(q).toContain('  events(first: $first, after: $after) {')
+    expect(q).toContain('      ...Event')
+    expect(q).toContain('    pageInfo {')
+    expect(q).toContain('      hasNextPage')
+  })
+
+  it('emits a ByUri query when the idType enum contains URI', () => {
+    const q = buildCptQueries(FULL_EVENT_CPT)
+    expect(q).toContain('query EventByUri($uri: ID!) {')
+    expect(q).toContain('  event(id: $uri, idType: URI) {')
+  })
+
+  it('emits a BySlug query when the idType enum contains SLUG', () => {
+    const q = buildCptQueries(FULL_EVENT_CPT)
+    expect(q).toContain('query EventBySlug($slug: ID!) {')
+    expect(q).toContain('  event(id: $slug, idType: SLUG) {')
+  })
+
+  it('omits the ByUri query when URI is not in the idType enum', () => {
+    const noUri: DiscoveredCpt = {
+      ...FULL_EVENT_CPT,
+      supportedIdTypes: new Set(['DATABASE_ID', 'ID', 'SLUG'])
+    }
+    const q = buildCptQueries(noUri)
+    expect(q).not.toContain('ByUri')
+    expect(q).toContain('BySlug')
+  })
+
+  it('omits the BySlug query when SLUG is not in the idType enum', () => {
+    const noSlug: DiscoveredCpt = {
+      ...FULL_EVENT_CPT,
+      supportedIdTypes: new Set(['DATABASE_ID', 'ID', 'URI'])
+    }
+    const q = buildCptQueries(noSlug)
+    expect(q).not.toContain('BySlug')
+    expect(q).toContain('ByUri')
+  })
+})
+
+describe('writeCptArtifacts', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'wpnuxt-gen-'))
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('writes Event.fragment.gql and Events.gql (plural) into the output folder', async () => {
+    const result = await writeCptArtifacts(FULL_EVENT_CPT, tmpDir)
+    expect(result.wroteFragment).toBe(true)
+    expect(result.wroteQueries).toBe(true)
+    expect(existsSync(join(tmpDir, 'fragments/Event.fragment.gql'))).toBe(true)
+    expect(existsSync(join(tmpDir, 'Events.gql'))).toBe(true)
+  })
+
+  it('does not overwrite an existing fragment file', async () => {
+    const { mkdirSync } = await import('node:fs')
+    mkdirSync(join(tmpDir, 'fragments'), { recursive: true })
+    writeFileSync(join(tmpDir, 'fragments/Event.fragment.gql'), 'USER FRAGMENT', 'utf8')
+    const result = await writeCptArtifacts(FULL_EVENT_CPT, tmpDir)
+    expect(result.wroteFragment).toBe(false)
+    expect(readFileSync(join(tmpDir, 'fragments/Event.fragment.gql'), 'utf8')).toBe('USER FRAGMENT')
+  })
+
+  it('does not overwrite an existing query file', async () => {
+    writeFileSync(join(tmpDir, 'Events.gql'), 'USER QUERIES', 'utf8')
+    const result = await writeCptArtifacts(FULL_EVENT_CPT, tmpDir)
+    expect(result.wroteQueries).toBe(false)
+    expect(readFileSync(join(tmpDir, 'Events.gql'), 'utf8')).toBe('USER QUERIES')
+  })
+})

--- a/playgrounds/blocks/schema.graphql
+++ b/playgrounds/blocks/schema.graphql
@@ -2116,6 +2116,9 @@ enum ContentTypeEnum {
 
   """The Type of Content object"""
   POST
+
+  """The Type of Content object"""
+  SPONSOR
 }
 
 """
@@ -2299,7 +2302,7 @@ enum ContentTypesOfTagEnum {
 }
 
 """A block used for editing the site"""
-type CoreAccordion implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreAccordion implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -2434,7 +2437,7 @@ type CoreAccordionAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreAccordionHeading implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreAccordionHeading implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -2554,7 +2557,7 @@ type CoreAccordionHeadingAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreAccordionItem implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreAccordionItem implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -2653,7 +2656,7 @@ type CoreAccordionItemAttributes {
 }
 
 """A block used for editing the site"""
-type CoreAccordionPanel implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreAccordionPanel implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -2757,7 +2760,7 @@ type CoreAccordionPanelAttributes {
 }
 
 """A block used for editing the site"""
-type CoreArchives implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreArchives implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -2871,7 +2874,7 @@ type CoreArchivesAttributes {
 }
 
 """A block used for editing the site"""
-type CoreAudio implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreAudio implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -2976,7 +2979,7 @@ type CoreAudioAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreAvatar implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreAvatar implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -3065,7 +3068,7 @@ type CoreAvatarAttributes {
 }
 
 """A block used for editing the site"""
-type CoreBlock implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreBlock implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -3124,7 +3127,7 @@ type CoreBlockAttributes {
 }
 
 """A block used for editing the site"""
-type CoreButton implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreButton implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -3279,7 +3282,7 @@ type CoreButtonAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreButtons implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreButtons implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -3384,7 +3387,7 @@ type CoreButtonsAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreCalendar implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCalendar implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -3478,7 +3481,7 @@ type CoreCalendarAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCategories implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCategories implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -3612,7 +3615,7 @@ type CoreCategoriesAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCode implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCode implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -3722,7 +3725,7 @@ type CoreCodeAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreColumn implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreColumn implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -3837,7 +3840,7 @@ type CoreColumnAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreColumns implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreColumns implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -3957,7 +3960,7 @@ type CoreColumnsAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreCommentAuthorName implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCommentAuthorName implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -4061,7 +4064,7 @@ type CoreCommentAuthorNameAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCommentContent implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCommentContent implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -4155,7 +4158,7 @@ type CoreCommentContentAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCommentDate implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCommentDate implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -4254,7 +4257,7 @@ type CoreCommentDateAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCommentEditLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCommentEditLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -4348,7 +4351,7 @@ type CoreCommentEditLinkAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCommentReplyLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCommentReplyLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -4437,7 +4440,7 @@ type CoreCommentReplyLinkAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCommentTemplate implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCommentTemplate implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -4516,7 +4519,7 @@ type CoreCommentTemplateAttributes {
 }
 
 """A block used for editing the site"""
-type CoreComments implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreComments implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -4620,7 +4623,7 @@ type CoreCommentsAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCommentsPagination implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCommentsPagination implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -4719,7 +4722,7 @@ type CoreCommentsPaginationAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCommentsPaginationNext implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCommentsPaginationNext implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -4803,7 +4806,7 @@ type CoreCommentsPaginationNextAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCommentsPaginationNumbers implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCommentsPaginationNumbers implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -4882,7 +4885,7 @@ type CoreCommentsPaginationNumbersAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCommentsPaginationPrevious implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCommentsPaginationPrevious implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -4966,7 +4969,7 @@ type CoreCommentsPaginationPreviousAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCommentsTitle implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCommentsTitle implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -5085,7 +5088,7 @@ type CoreCommentsTitleAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCover implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCover implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -5285,7 +5288,7 @@ type CoreCoverAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreDetails implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreDetails implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -5410,7 +5413,7 @@ type CoreDetailsAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreEmbed implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreEmbed implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -5509,7 +5512,7 @@ type CoreEmbedAttributes {
 }
 
 """A block used for editing the site"""
-type CoreFile implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreFile implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -5649,7 +5652,7 @@ type CoreFileAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreFootnotes implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreFootnotes implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -5733,7 +5736,7 @@ type CoreFootnotesAttributes {
 }
 
 """A block used for editing the site"""
-type CoreFreeform implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreFreeform implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -5787,7 +5790,7 @@ type CoreFreeformAttributes {
 }
 
 """A block used for editing the site"""
-type CoreGallery implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreGallery implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -5977,7 +5980,7 @@ type CoreGalleryAttributesImages {
 }
 
 """A block used for editing the site"""
-type CoreGroup implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreGroup implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -6097,7 +6100,7 @@ type CoreGroupAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreHeading implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreHeading implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -6227,7 +6230,7 @@ type CoreHeadingAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreHomeLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreHomeLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -6301,7 +6304,7 @@ type CoreHomeLinkAttributes {
 }
 
 """A block used for editing the site"""
-type CoreHtml implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreHtml implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -6355,7 +6358,7 @@ type CoreHtmlAttributes {
 }
 
 """A block used for editing the site"""
-type CoreImage implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreImage implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -6528,7 +6531,7 @@ type CoreImageAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreLatestComments implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreLatestComments implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -6637,7 +6640,7 @@ type CoreLatestCommentsAttributes {
 }
 
 """A block used for editing the site"""
-type CoreLatestPosts implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreLatestPosts implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -6821,7 +6824,7 @@ type CoreLatestPostsAttributes {
 }
 
 """A block used for editing the site"""
-type CoreLegacyWidget implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreLegacyWidget implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -6885,7 +6888,7 @@ type CoreLegacyWidgetAttributes {
 }
 
 """A block used for editing the site"""
-type CoreList implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreList implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -7015,7 +7018,7 @@ type CoreListAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreListItem implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreListItem implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -7120,7 +7123,7 @@ type CoreListItemAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreLoginout implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreLoginout implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -7214,7 +7217,7 @@ type CoreLoginoutAttributes {
 }
 
 """A block used for editing the site"""
-type CoreMath implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreMath implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -7278,7 +7281,7 @@ type CoreMathAttributes {
 }
 
 """A block used for editing the site"""
-type CoreMediaText implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreMediaText implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -7468,7 +7471,7 @@ type CoreMediaTextAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreMissing implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreMissing implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -7532,7 +7535,7 @@ type CoreMissingAttributes {
 }
 
 """A block used for editing the site"""
-type CoreMore implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreMore implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -7591,7 +7594,7 @@ type CoreMoreAttributes {
 }
 
 """A block used for editing the site"""
-type CoreNavigation implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreNavigation implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -7765,7 +7768,7 @@ type CoreNavigationAttributes {
 }
 
 """A block used for editing the site"""
-type CoreNavigationLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreNavigationLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -7884,7 +7887,7 @@ type CoreNavigationLinkAttributes {
 }
 
 """A block used for editing the site"""
-type CoreNavigationSubmenu implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreNavigationSubmenu implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -8003,7 +8006,7 @@ type CoreNavigationSubmenuAttributes {
 }
 
 """A block used for editing the site"""
-type CoreNextpage implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreNextpage implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -8052,7 +8055,7 @@ type CoreNextpageAttributes {
 }
 
 """A block used for editing the site"""
-type CorePageList implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePageList implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -8151,7 +8154,7 @@ type CorePageListAttributes {
 }
 
 """A block used for editing the site"""
-type CorePageListItem implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePageListItem implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -8230,7 +8233,7 @@ type CorePageListItemAttributes {
 }
 
 """A block used for editing the site"""
-type CoreParagraph implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreParagraph implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -8355,7 +8358,7 @@ type CoreParagraphAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CorePattern implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePattern implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -8414,7 +8417,7 @@ type CorePatternAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostAuthor implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostAuthor implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -8538,7 +8541,7 @@ type CorePostAuthorAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostAuthorBiography implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostAuthorBiography implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -8632,7 +8635,7 @@ type CorePostAuthorBiographyAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostAuthorName implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostAuthorName implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -8736,7 +8739,7 @@ type CorePostAuthorNameAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostComments implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostComments implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -8825,7 +8828,7 @@ type CorePostCommentsAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostCommentsCount implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostCommentsCount implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -8919,7 +8922,7 @@ type CorePostCommentsCountAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostCommentsForm implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostCommentsForm implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -9008,7 +9011,7 @@ type CorePostCommentsFormAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostCommentsLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostCommentsLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -9092,7 +9095,7 @@ type CorePostCommentsLinkAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostContent implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostContent implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -9196,7 +9199,7 @@ type CorePostContentAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostDate implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostDate implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -9305,7 +9308,7 @@ type CorePostDateAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostExcerpt implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostExcerpt implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -9414,7 +9417,7 @@ type CorePostExcerptAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostFeaturedImage implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostFeaturedImage implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -9553,7 +9556,7 @@ type CorePostFeaturedImageAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostNavigationLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostNavigationLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -9667,7 +9670,7 @@ type CorePostNavigationLinkAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostTemplate implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostTemplate implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -9766,7 +9769,7 @@ type CorePostTemplateAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostTerms implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostTerms implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -9960,7 +9963,7 @@ type CorePostTermsToTermNodeConnectionPageInfo implements PageInfo & TermNodeCon
 }
 
 """A block used for editing the site"""
-type CorePostTimeToRead implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostTimeToRead implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -10069,7 +10072,7 @@ type CorePostTimeToReadAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostTitle implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostTitle implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -10193,7 +10196,7 @@ type CorePostTitleAttributes {
 }
 
 """A block used for editing the site"""
-type CorePreformatted implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePreformatted implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -10293,7 +10296,7 @@ type CorePreformattedAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CorePullquote implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePullquote implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -10408,7 +10411,7 @@ type CorePullquoteAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreQuery implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreQuery implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -10497,7 +10500,7 @@ type CoreQueryAttributes {
 }
 
 """A block used for editing the site"""
-type CoreQueryNoResults implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreQueryNoResults implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -10586,7 +10589,7 @@ type CoreQueryNoResultsAttributes {
 }
 
 """A block used for editing the site"""
-type CoreQueryPagination implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreQueryPagination implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -10690,7 +10693,7 @@ type CoreQueryPaginationAttributes {
 }
 
 """A block used for editing the site"""
-type CoreQueryPaginationNext implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreQueryPaginationNext implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -10774,7 +10777,7 @@ type CoreQueryPaginationNextAttributes {
 }
 
 """A block used for editing the site"""
-type CoreQueryPaginationNumbers implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreQueryPaginationNumbers implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -10858,7 +10861,7 @@ type CoreQueryPaginationNumbersAttributes {
 }
 
 """A block used for editing the site"""
-type CoreQueryPaginationPrevious implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreQueryPaginationPrevious implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -10942,7 +10945,7 @@ type CoreQueryPaginationPreviousAttributes {
 }
 
 """A block used for editing the site"""
-type CoreQueryTitle implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreQueryTitle implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -11066,7 +11069,7 @@ type CoreQueryTitleAttributes {
 }
 
 """A block used for editing the site"""
-type CoreQueryTotal implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreQueryTotal implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -11165,7 +11168,7 @@ type CoreQueryTotalAttributes {
 }
 
 """A block used for editing the site"""
-type CoreQuote implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreQuote implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -11290,7 +11293,7 @@ type CoreQuoteAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreReadMore implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreReadMore implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -11389,7 +11392,7 @@ type CoreReadMoreAttributes {
 }
 
 """A block used for editing the site"""
-type CoreRss implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreRss implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -11523,7 +11526,7 @@ type CoreRssAttributes {
 }
 
 """A block used for editing the site"""
-type CoreSearch implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreSearch implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -11667,7 +11670,7 @@ type CoreSearchAttributes {
 }
 
 """A block used for editing the site"""
-type CoreSeparator implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreSeparator implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -11762,7 +11765,7 @@ type CoreSeparatorAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreShortcode implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreShortcode implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -11816,7 +11819,7 @@ type CoreShortcodeAttributes {
 }
 
 """A block used for editing the site"""
-type CoreSiteLogo implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreSiteLogo implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -11900,7 +11903,7 @@ type CoreSiteLogoAttributes {
 }
 
 """A block used for editing the site"""
-type CoreSiteTagline implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreSiteTagline implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -12009,7 +12012,7 @@ type CoreSiteTaglineAttributes {
 }
 
 """A block used for editing the site"""
-type CoreSiteTitle implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreSiteTitle implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -12128,7 +12131,7 @@ type CoreSiteTitleAttributes {
 }
 
 """A block used for editing the site"""
-type CoreSocialLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreSocialLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -12202,7 +12205,7 @@ type CoreSocialLinkAttributes {
 }
 
 """A block used for editing the site"""
-type CoreSocialLinks implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreSocialLinks implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -12337,7 +12340,7 @@ type CoreSocialLinksAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreSpacer implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreSpacer implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -12412,7 +12415,7 @@ type CoreSpacerAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreTable implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreTable implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -12672,7 +12675,7 @@ type CoreTableAttributesHeadCells {
 }
 
 """A block used for editing the site"""
-type CoreTagCloud implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreTagCloud implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -12771,7 +12774,7 @@ type CoreTagCloudAttributes {
 }
 
 """A block used for editing the site"""
-type CoreTemplatePart implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreTemplatePart implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -12850,7 +12853,7 @@ type CoreTemplatePartAttributes {
 }
 
 """A block used for editing the site"""
-type CoreTermCount implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreTermCount implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -12944,7 +12947,7 @@ type CoreTermCountAttributes {
 }
 
 """A block used for editing the site"""
-type CoreTermDescription implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreTermDescription implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -13038,7 +13041,7 @@ type CoreTermDescriptionAttributes {
 }
 
 """A block used for editing the site"""
-type CoreTermName implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreTermName implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -13147,7 +13150,7 @@ type CoreTermNameAttributes {
 }
 
 """A block used for editing the site"""
-type CoreTermTemplate implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreTermTemplate implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -13246,7 +13249,7 @@ type CoreTermTemplateAttributes {
 }
 
 """A block used for editing the site"""
-type CoreTermsQuery implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreTermsQuery implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -13320,7 +13323,7 @@ type CoreTermsQueryAttributes {
 }
 
 """A block used for editing the site"""
-type CoreTextColumns implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreTextColumns implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -13399,7 +13402,7 @@ type CoreTextColumnsAttributesContent {
 }
 
 """A block used for editing the site"""
-type CoreVerse implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreVerse implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -13504,7 +13507,7 @@ type CoreVerseAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreVideo implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreVideo implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -13634,7 +13637,7 @@ type CoreVideoAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreWidgetGroup implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreWidgetGroup implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -14099,6 +14102,53 @@ type CreatePostPayload {
   post: Post
 }
 
+"""Input for the createSponsor mutation."""
+input CreateSponsorInput {
+  """
+  This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions.
+  """
+  clientMutationId: String
+
+  """The content of the object"""
+  content: String
+
+  """
+  The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17 
+  """
+  date: String
+
+  """The excerpt of the object"""
+  excerpt: String
+
+  """
+  A field used for ordering posts. This is typically used with nav menu items or for special ordering of hierarchical content types.
+  """
+  menuOrder: Int
+
+  """The password used to protect the content of the object"""
+  password: String
+
+  """The slug of the object"""
+  slug: String
+
+  """The status of the object"""
+  status: PostStatusEnum
+
+  """The title of the object"""
+  title: String
+}
+
+"""The payload for the createSponsor mutation."""
+type CreateSponsorPayload {
+  """
+  If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
+  """
+  clientMutationId: String
+
+  """The Post object mutation type."""
+  sponsor: Sponsor
+}
+
 """Input for the createTag mutation."""
 input CreateTagInput {
   """The slug that the post_tag will be an alias of"""
@@ -14508,6 +14558,39 @@ type DeletePostPayload {
 
   """The object before it was deleted"""
   post: Post
+}
+
+"""Input for the deleteSponsor mutation."""
+input DeleteSponsorInput {
+  """
+  This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions.
+  """
+  clientMutationId: String
+
+  """
+  Whether the object should be force deleted instead of being moved to the trash
+  """
+  forceDelete: Boolean
+
+  """The ID of the Sponsor to delete"""
+  id: ID!
+
+  """Override the edit lock when another user is editing the post"""
+  ignoreEditLock: Boolean
+}
+
+"""The payload for the deleteSponsor mutation."""
+type DeleteSponsorPayload {
+  """
+  If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
+  """
+  clientMutationId: String
+
+  """The ID of the deleted object"""
+  deletedId: ID
+
+  """The object before it was deleted"""
+  sponsor: Sponsor
 }
 
 """Input for the deleteTag mutation."""
@@ -18428,7 +18511,7 @@ enum MenuItemNodeIdTypeEnum {
 }
 
 """Deprecated in favor of MenuItemLinkable Interface"""
-union MenuItemObjectUnion = Category | Event | EventCategory | Page | Post | PostFormat | Tag
+union MenuItemObjectUnion = Category | Event | EventCategory | Page | Post | PostFormat | Sponsor | Tag
 
 """Connection between the MenuItem type and the Menu type"""
 type MenuItemToMenuConnectionEdge implements Edge & MenuConnectionEdge & OneToOneConnection {
@@ -19085,6 +19168,15 @@ type NodeWithRevisionsToContentNodeConnectionEdge implements ContentNodeConnecti
 
   """The node of the connection, without the edges"""
   node: ContentNode!
+}
+
+"""Node that has Sponsor content blocks associated with it"""
+interface NodeWithSponsorEditorBlocks implements NodeWithEditorBlocks {
+  """List of Sponsor editor blocks"""
+  editorBlocks(
+    """Returns the list of blocks as a flat list if true"""
+    flat: Boolean
+  ): [SponsorEditorBlock]
 }
 
 """
@@ -22576,6 +22668,12 @@ type RootMutation {
     input: CreatePostFormatInput!
   ): CreatePostFormatPayload
 
+  """The createSponsor mutation"""
+  createSponsor(
+    """Input for the createSponsor mutation"""
+    input: CreateSponsorInput!
+  ): CreateSponsorPayload
+
   """The createTag mutation"""
   createTag(
     """Input for the createTag mutation"""
@@ -22635,6 +22733,12 @@ type RootMutation {
     """Input for the deletePostFormat mutation"""
     input: DeletePostFormatInput!
   ): DeletePostFormatPayload
+
+  """The deleteSponsor mutation"""
+  deleteSponsor(
+    """Input for the deleteSponsor mutation"""
+    input: DeleteSponsorInput!
+  ): DeleteSponsorPayload
 
   """The deleteTag mutation"""
   deleteTag(
@@ -22769,6 +22873,12 @@ type RootMutation {
     """Input for the updateSettings mutation"""
     input: UpdateSettingsInput!
   ): UpdateSettingsPayload
+
+  """The updateSponsor mutation"""
+  updateSponsor(
+    """Input for the updateSponsor mutation"""
+    input: UpdateSponsorInput!
+  ): UpdateSponsorPayload
 
   """The updateTag mutation"""
   updateTag(
@@ -23382,6 +23492,59 @@ type RootQuery {
 
   """Returns seo site data"""
   seo: SEOConfig
+
+  """An object of the Sponsor Type. """
+  sponsor(
+    """
+    Whether to return the Preview Node instead of the Published Node. When the ID of a Node is provided along with asPreview being set to true, the preview node with un-published changes will be returned instead of the published node. If no preview node exists or the requester doesn't have proper capabilities to preview, no node will be returned. If the ID provided is a URI and has a preview query arg, it will be used as a fallback if the "asPreview" argument is not explicitly provided as an argument.
+    """
+    asPreview: Boolean
+
+    """The globally unique identifier of the object."""
+    id: ID!
+
+    """Type of unique identifier to fetch by. Default is Global ID"""
+    idType: SponsorIdType
+  ): Sponsor
+
+  """A Sponsor object"""
+  sponsorBy(
+    """Get the Sponsor object by its global ID"""
+    id: ID
+
+    """
+    Get the Sponsor by its slug (only available for non-hierarchical types)
+    """
+    slug: String
+
+    """Get the Sponsor by its database ID"""
+    sponsorId: Int
+
+    """Get the Sponsor by its uri"""
+    uri: String
+  ): Sponsor @deprecated(reason: "Deprecated in favor of using the single entry point for this type with ID and IDType fields. For example, instead of postBy( id: &quot;&quot; ), use post(id: &quot;&quot; idType: &quot;&quot;)")
+
+  """Connection between the RootQuery type and the Sponsor type"""
+  sponsors(
+    """
+    Cursor used along with the "first" argument to reference where in the dataset to get data
+    """
+    after: String
+
+    """
+    Cursor used along with the "last" argument to reference where in the dataset to get data
+    """
+    before: String
+
+    """The number of items to return after the referenced "after" cursor"""
+    first: Int
+
+    """The number of items to return before the referenced "before" cursor"""
+    last: Int
+
+    """Arguments for filtering the connection"""
+    where: RootQueryToSponsorConnectionWhereArgs
+  ): RootQueryToSponsorConnection
 
   """A 0bject"""
   tag(
@@ -25059,6 +25222,105 @@ input RootQueryToRevisionsConnectionWhereArgs {
   title: String
 }
 
+"""Connection between the RootQuery type and the Sponsor type"""
+type RootQueryToSponsorConnection implements Connection & SponsorConnection {
+  """Edges for the RootQueryToSponsorConnection connection"""
+  edges: [RootQueryToSponsorConnectionEdge!]!
+
+  """The nodes of the connection, without the edges"""
+  nodes: [Sponsor!]!
+
+  """Information about pagination in a connection."""
+  pageInfo: RootQueryToSponsorConnectionPageInfo!
+}
+
+"""An edge in a connection"""
+type RootQueryToSponsorConnectionEdge implements Edge & SponsorConnectionEdge {
+  """A cursor for use in pagination"""
+  cursor: String
+
+  """The item at the end of the edge"""
+  node: Sponsor!
+}
+
+"""
+Pagination metadata specific to &quot;RootQueryToSponsorConnection&quot; collections. Provides cursors and flags for navigating through sets of RootQueryToSponsorConnection Nodes.
+"""
+type RootQueryToSponsorConnectionPageInfo implements PageInfo & SponsorConnectionPageInfo & WPPageInfo {
+  """When paginating forwards, the cursor to continue."""
+  endCursor: String
+
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+
+  """Raw schema for page"""
+  seo: SEOPostTypePageInfo
+
+  """When paginating backwards, the cursor to continue."""
+  startCursor: String
+}
+
+"""Arguments for filtering the RootQueryToSponsorConnection connection"""
+input RootQueryToSponsorConnectionWhereArgs {
+  """Filter the connection based on dates"""
+  dateQuery: DateQueryInput
+
+  """
+  True for objects with passwords; False for objects without passwords; null for all objects with or without passwords
+  """
+  hasPassword: Boolean
+
+  """Specific database ID of the object"""
+  id: Int
+
+  """Array of IDs for the objects to retrieve"""
+  in: [ID]
+
+  """Get objects with a specific mimeType property"""
+  mimeType: MimeTypeEnum
+
+  """Slug / post_name of the object"""
+  name: String
+
+  """Specify objects to retrieve. Use slugs"""
+  nameIn: [String]
+
+  """
+  Specify IDs NOT to retrieve. If this is used in the same query as "in", it will be ignored
+  """
+  notIn: [ID]
+
+  """What parameter to use to order the objects by."""
+  orderby: [PostObjectsConnectionOrderbyInput]
+
+  """Use ID to return only children. Use 0 to return only top-level items"""
+  parent: ID
+
+  """Specify objects whose parent is in an array"""
+  parentIn: [ID]
+
+  """Specify posts whose parent is not in an array"""
+  parentNotIn: [ID]
+
+  """Show posts with a specific password."""
+  password: String
+
+  """Show Posts based on a keyword search"""
+  search: String
+
+  """Retrieve posts where post status is in an array."""
+  stati: [PostStatusEnum]
+
+  """Show posts with a specific status."""
+  status: PostStatusEnum
+
+  """Title of the object"""
+  title: String
+}
+
 """Connection between the RootQuery type and the tag type"""
 type RootQueryToTagConnection implements Connection & TagConnection {
   """Edges for the RootQueryToTagConnection connection"""
@@ -25679,6 +25941,9 @@ type SEOContentTypes {
 
   """"""
   post: SEOContentType
+
+  """"""
+  sponsor: SEOContentType
 }
 
 """The Yoast SEO meta data"""
@@ -26165,6 +26430,515 @@ type SiteTokenClientOptions implements LoginClientOptions {
 type SiteTokenLoginOptions implements LoginOptions {
   """Whether to set a WordPress authentication cookie on successful login."""
   useAuthenticationCookie: Boolean
+}
+
+"""The Sponsor type"""
+type Sponsor implements ContentNode & DatabaseIdentifier & MenuItemLinkable & Node & NodeWithContentEditor & NodeWithEditorBlocks & NodeWithExcerpt & NodeWithFeaturedImage & NodeWithRevisions & NodeWithSponsorEditorBlocks & NodeWithTemplate & NodeWithTitle & Previewable & UniformResourceIdentifiable {
+  """The ancestors of the content node."""
+  ancestors(
+    """
+    Cursor used along with the "first" argument to reference where in the dataset to get data
+    """
+    after: String
+
+    """
+    Cursor used along with the "last" argument to reference where in the dataset to get data
+    """
+    before: String
+
+    """The number of items to return after the referenced "after" cursor"""
+    first: Int
+
+    """The number of items to return before the referenced "before" cursor"""
+    last: Int
+  ): SponsorToSponsorConnection @deprecated(reason: "This content type is not hierarchical and typically will not have ancestors")
+
+  """"""
+  conditionalTags: ConditionalTags @deprecated(reason: "Deprecated in favor of using Next.js pages")
+
+  """The content of the post."""
+  content(
+    """Format of the field output"""
+    format: PostObjectFieldFormatEnum
+  ): String
+
+  """Connection between the ContentNode type and the ContentType type"""
+  contentType: ContentNodeToContentTypeConnectionEdge
+
+  """The name of the Content Type the node belongs to"""
+  contentTypeName: String!
+
+  """The unique identifier stored in the database"""
+  databaseId: Int!
+
+  """Post publishing date."""
+  date: String
+
+  """The publishing date set in GMT."""
+  dateGmt: String
+
+  """The desired slug of the post"""
+  desiredSlug: String
+
+  """
+  If a user has edited the node within the past 15 seconds, this will return the user that last edited. Null if the edit lock doesn&#039;t exist or is greater than 15 seconds
+  """
+  editingLockedBy: ContentNodeToEditLockConnectionEdge
+
+  """List of Sponsor editor blocks"""
+  editorBlocks(
+    """Returns the list of blocks as a flat list if true"""
+    flat: Boolean
+  ): [SponsorEditorBlock]
+
+  """The RSS enclosure for the object"""
+  enclosure: String
+
+  """Connection between the ContentNode type and the EnqueuedScript type"""
+  enqueuedScripts(
+    """
+    Cursor used along with the "first" argument to reference where in the dataset to get data
+    """
+    after: String
+
+    """
+    Cursor used along with the "last" argument to reference where in the dataset to get data
+    """
+    before: String
+
+    """The number of items to return after the referenced "after" cursor"""
+    first: Int
+
+    """The number of items to return before the referenced "before" cursor"""
+    last: Int
+  ): ContentNodeToEnqueuedScriptConnection
+
+  """
+  Connection between the ContentNode type and the EnqueuedStylesheet type
+  """
+  enqueuedStylesheets(
+    """
+    Cursor used along with the "first" argument to reference where in the dataset to get data
+    """
+    after: String
+
+    """
+    Cursor used along with the "last" argument to reference where in the dataset to get data
+    """
+    before: String
+
+    """The number of items to return after the referenced "after" cursor"""
+    first: Int
+
+    """The number of items to return before the referenced "before" cursor"""
+    last: Int
+  ): ContentNodeToEnqueuedStylesheetConnection
+
+  """The excerpt of the post."""
+  excerpt(
+    """Format of the field output"""
+    format: PostObjectFieldFormatEnum
+  ): String
+
+  """
+  Connection between the NodeWithFeaturedImage type and the MediaItem type
+  """
+  featuredImage: NodeWithFeaturedImageToMediaItemConnectionEdge
+
+  """
+  The database identifier for the featured image node assigned to the content node
+  """
+  featuredImageDatabaseId: Int
+
+  """Globally unique ID of the featured image assigned to the node"""
+  featuredImageId: ID
+
+  """
+  The global unique identifier for this post. This currently matches the value stored in WP_Post-&gt;guid and the guid column in the &quot;post_objects&quot; database table.
+  """
+  guid: String
+
+  """Whether the sponsor object is password protected."""
+  hasPassword: Boolean
+
+  """The globally unique identifier of the sponsor object."""
+  id: ID!
+
+  """Whether the node is a Comment"""
+  isComment: Boolean!
+
+  """Whether the node is a Content Node"""
+  isContentNode: Boolean!
+
+  """Whether the node represents the front page."""
+  isFrontPage: Boolean!
+
+  """Whether  the node represents the blog page."""
+  isPostsPage: Boolean!
+
+  """Whether the object is a node in the preview state"""
+  isPreview: Boolean
+
+  """Whether the object is restricted from the current viewer"""
+  isRestricted: Boolean
+
+  """True if the node is a revision of another node"""
+  isRevision: Boolean
+
+  """Whether the node is a Term"""
+  isTermNode: Boolean!
+
+  """The user that most recently edited the node"""
+  lastEditedBy: ContentNodeToEditLastConnectionEdge
+
+  """The permalink of the post"""
+  link: String
+
+  """
+  The local modified time for a post. If a post was recently updated the modified field will change to match the corresponding time.
+  """
+  modified: String
+
+  """
+  The GMT modified time for a post. If a post was recently updated the modified field will change to match the corresponding time in GMT.
+  """
+  modifiedGmt: String
+
+  """The parent of the content node."""
+  parent: SponsorToParentConnectionEdge @deprecated(reason: "This content type is not hierarchical and typically will not have a parent")
+
+  """The password for the sponsor object."""
+  password: String
+
+  """Connection between the Sponsor type and the Sponsor type"""
+  preview: SponsorToPreviewConnectionEdge
+
+  """The database id of the preview node"""
+  previewRevisionDatabaseId: Int
+
+  """Whether the object is a node in the preview state"""
+  previewRevisionId: ID
+
+  """
+  If the current node is a revision, this field exposes the node this is a revision of. Returns null if the node is not a revision of another node.
+  """
+  revisionOf: NodeWithRevisionsToContentNodeConnectionEdge
+
+  """Connection between the Sponsor type and the Sponsor type"""
+  revisions(
+    """
+    Cursor used along with the "first" argument to reference where in the dataset to get data
+    """
+    after: String
+
+    """
+    Cursor used along with the "last" argument to reference where in the dataset to get data
+    """
+    before: String
+
+    """The number of items to return after the referenced "after" cursor"""
+    first: Int
+
+    """The number of items to return before the referenced "before" cursor"""
+    last: Int
+
+    """Arguments for filtering the connection"""
+    where: SponsorToRevisionConnectionWhereArgs
+  ): SponsorToRevisionConnection
+
+  """The Yoast SEO data of the ContentNode"""
+  seo: PostTypeSEO
+
+  """
+  The uri slug for the post. This is equivalent to the WP_Post-&gt;post_name field and the post_name column in the database for the &quot;post_objects&quot; table.
+  """
+  slug: String
+
+  """The id field matches the WP_Post-&gt;ID field."""
+  sponsorId: Int! @deprecated(reason: "Deprecated in favor of the databaseId field")
+
+  """The current status of the object"""
+  status: String
+
+  """The template assigned to the node"""
+  template: ContentTemplate
+
+  """"""
+  templates: [String]
+
+  """
+  The title of the post. This is currently just the raw title. An amendment to support rendered title needs to be made.
+  """
+  title(
+    """Format of the field output"""
+    format: PostObjectFieldFormatEnum
+  ): String
+
+  """The unique resource identifier path"""
+  uri: String
+}
+
+"""
+A paginated collection of Sponsor Nodes, Supports cursor-based pagination and filtering to efficiently retrieve sets of Sponsor Nodes
+"""
+interface SponsorConnection implements Connection {
+  """
+  A list of edges (relational context) between RootQuery and connected Sponsor Nodes
+  """
+  edges: [SponsorConnectionEdge!]!
+
+  """A list of connected Sponsor Nodes"""
+  nodes: [Sponsor!]!
+
+  """Information about pagination in a connection."""
+  pageInfo: SponsorConnectionPageInfo!
+}
+
+"""
+Represents a connection to a Sponsor. Contains both the Sponsor Node and metadata about the relationship.
+"""
+interface SponsorConnectionEdge implements Edge {
+  """
+  Opaque reference to the nodes position in the connection. Value can be used with pagination args.
+  """
+  cursor: String
+
+  """The connected Sponsor Node"""
+  node: Sponsor!
+}
+
+"""
+Pagination metadata specific to &quot;SponsorConnectionEdge&quot; collections. Provides cursors and flags for navigating through sets of &quot;SponsorConnectionEdge&quot; Nodes.
+"""
+interface SponsorConnectionPageInfo implements PageInfo & WPPageInfo {
+  """When paginating forwards, the cursor to continue."""
+  endCursor: String
+
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+
+  """Raw schema for page"""
+  seo: SEOPostTypePageInfo
+
+  """When paginating backwards, the cursor to continue."""
+  startCursor: String
+}
+
+"""EditorBlock Interface for Sponsor Block Type"""
+interface SponsorEditorBlock implements EditorBlock {
+  """The API version of the Gutenberg Block"""
+  apiVersion: Int
+
+  """The name of the category the Block belongs to"""
+  blockEditorCategoryName: String
+
+  """The id of the Block"""
+  clientId: String
+
+  """CSS Classnames to apply to the block"""
+  cssClassNames: [String]
+
+  """The inner blocks of the Block"""
+  innerBlocks: [EditorBlock]
+
+  """Whether the block is Dynamic (server rendered)"""
+  isDynamic: Boolean!
+
+  """The name of the Block"""
+  name: String
+
+  """The parent id of the Block"""
+  parentClientId: String
+
+  """The rendered HTML for the block"""
+  renderedHtml: String
+
+  """The (GraphQL) type of the block"""
+  type: String
+}
+
+"""
+Identifier types for retrieving a specific Sponsor. Specifies which unique attribute is used to find an exact Sponsor.
+"""
+enum SponsorIdType {
+  """Identify a resource by the Database ID."""
+  DATABASE_ID
+
+  """Identify a resource by the (hashed) Global ID."""
+  ID
+
+  """
+  Identify a resource by the slug. Available to non-hierarchcial Types where the slug is a unique identifier.
+  """
+  SLUG
+
+  """Identify a resource by the URI."""
+  URI
+}
+
+"""Connection between the Sponsor type and the Sponsor type"""
+type SponsorToParentConnectionEdge implements Edge & OneToOneConnection & SponsorConnectionEdge {
+  """
+  Opaque reference to the nodes position in the connection. Value can be used with pagination args.
+  """
+  cursor: String
+
+  """The node of the connection, without the edges"""
+  node: Sponsor! @deprecated(reason: "This content type is not hierarchical and typically will not have a parent")
+}
+
+"""Connection between the Sponsor type and the Sponsor type"""
+type SponsorToPreviewConnectionEdge implements Edge & OneToOneConnection & SponsorConnectionEdge {
+  """
+  Opaque reference to the nodes position in the connection. Value can be used with pagination args.
+  """
+  cursor: String
+
+  """The node of the connection, without the edges"""
+  node: Sponsor!
+}
+
+"""Connection between the Sponsor type and the Sponsor type"""
+type SponsorToRevisionConnection implements Connection & SponsorConnection {
+  """Edges for the SponsorToRevisionConnection connection"""
+  edges: [SponsorToRevisionConnectionEdge!]!
+
+  """The nodes of the connection, without the edges"""
+  nodes: [Sponsor!]!
+
+  """Information about pagination in a connection."""
+  pageInfo: SponsorToRevisionConnectionPageInfo!
+}
+
+"""An edge in a connection"""
+type SponsorToRevisionConnectionEdge implements Edge & SponsorConnectionEdge {
+  """A cursor for use in pagination"""
+  cursor: String
+
+  """The item at the end of the edge"""
+  node: Sponsor!
+}
+
+"""
+Pagination metadata specific to &quot;SponsorToRevisionConnection&quot; collections. Provides cursors and flags for navigating through sets of SponsorToRevisionConnection Nodes.
+"""
+type SponsorToRevisionConnectionPageInfo implements PageInfo & SponsorConnectionPageInfo & WPPageInfo {
+  """When paginating forwards, the cursor to continue."""
+  endCursor: String
+
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+
+  """Raw schema for page"""
+  seo: SEOPostTypePageInfo
+
+  """When paginating backwards, the cursor to continue."""
+  startCursor: String
+}
+
+"""Arguments for filtering the SponsorToRevisionConnection connection"""
+input SponsorToRevisionConnectionWhereArgs {
+  """Filter the connection based on dates"""
+  dateQuery: DateQueryInput
+
+  """
+  True for objects with passwords; False for objects without passwords; null for all objects with or without passwords
+  """
+  hasPassword: Boolean
+
+  """Specific database ID of the object"""
+  id: Int
+
+  """Array of IDs for the objects to retrieve"""
+  in: [ID]
+
+  """Get objects with a specific mimeType property"""
+  mimeType: MimeTypeEnum
+
+  """Slug / post_name of the object"""
+  name: String
+
+  """Specify objects to retrieve. Use slugs"""
+  nameIn: [String]
+
+  """
+  Specify IDs NOT to retrieve. If this is used in the same query as "in", it will be ignored
+  """
+  notIn: [ID]
+
+  """What parameter to use to order the objects by."""
+  orderby: [PostObjectsConnectionOrderbyInput]
+
+  """Use ID to return only children. Use 0 to return only top-level items"""
+  parent: ID
+
+  """Specify objects whose parent is in an array"""
+  parentIn: [ID]
+
+  """Specify posts whose parent is not in an array"""
+  parentNotIn: [ID]
+
+  """Show posts with a specific password."""
+  password: String
+
+  """Show Posts based on a keyword search"""
+  search: String
+
+  """Retrieve posts where post status is in an array."""
+  stati: [PostStatusEnum]
+
+  """Show posts with a specific status."""
+  status: PostStatusEnum
+
+  """Title of the object"""
+  title: String
+}
+
+"""Connection between the Sponsor type and the Sponsor type"""
+type SponsorToSponsorConnection implements Connection & SponsorConnection {
+  """Edges for the SponsorToSponsorConnection connection"""
+  edges: [SponsorToSponsorConnectionEdge!]!
+
+  """The nodes of the connection, without the edges"""
+  nodes: [Sponsor!]!
+
+  """Information about pagination in a connection."""
+  pageInfo: SponsorToSponsorConnectionPageInfo!
+}
+
+"""An edge in a connection"""
+type SponsorToSponsorConnectionEdge implements Edge & SponsorConnectionEdge {
+  """A cursor for use in pagination"""
+  cursor: String @deprecated(reason: "This content type is not hierarchical and typically will not have ancestors")
+
+  """The item at the end of the edge"""
+  node: Sponsor! @deprecated(reason: "This content type is not hierarchical and typically will not have ancestors")
+}
+
+"""
+Pagination metadata specific to &quot;SponsorToSponsorConnection&quot; collections. Provides cursors and flags for navigating through sets of SponsorToSponsorConnection Nodes.
+"""
+type SponsorToSponsorConnectionPageInfo implements PageInfo & SponsorConnectionPageInfo & WPPageInfo {
+  """When paginating forwards, the cursor to continue."""
+  endCursor: String
+
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+
+  """Raw schema for page"""
+  seo: SEOPostTypePageInfo
+
+  """When paginating backwards, the cursor to continue."""
+  startCursor: String
 }
 
 """
@@ -27935,6 +28709,59 @@ type UpdateSettingsPayload {
   writingSettings: WritingSettings
 }
 
+"""Input for the updateSponsor mutation."""
+input UpdateSponsorInput {
+  """
+  This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions.
+  """
+  clientMutationId: String
+
+  """The content of the object"""
+  content: String
+
+  """
+  The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17 
+  """
+  date: String
+
+  """The excerpt of the object"""
+  excerpt: String
+
+  """The ID of the Sponsor object"""
+  id: ID!
+
+  """Override the edit lock when another user is editing the post"""
+  ignoreEditLock: Boolean
+
+  """
+  A field used for ordering posts. This is typically used with nav menu items or for special ordering of hierarchical content types.
+  """
+  menuOrder: Int
+
+  """The password used to protect the content of the object"""
+  password: String
+
+  """The slug of the object"""
+  slug: String
+
+  """The status of the object"""
+  status: PostStatusEnum
+
+  """The title of the object"""
+  title: String
+}
+
+"""The payload for the updateSponsor mutation."""
+type UpdateSponsorPayload {
+  """
+  If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
+  """
+  clientMutationId: String
+
+  """The Post object mutation type."""
+  sponsor: Sponsor
+}
+
 """Input for the updateTag mutation."""
 input UpdateTagInput {
   """The slug that the post_tag will be an alias of"""
@@ -29361,7 +30188,7 @@ type WritingSettings {
 }
 
 """A block used for editing the site"""
-type YoastFaqBlock implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type YoastFaqBlock implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -29425,7 +30252,7 @@ type YoastFaqBlockAttributes {
 }
 
 """A block used for editing the site"""
-type YoastHowToBlock implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type YoastHowToBlock implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -29534,7 +30361,7 @@ type YoastHowToBlockAttributes {
 }
 
 """A block used for editing the site"""
-type YoastSeoBreadcrumbs implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type YoastSeoBreadcrumbs implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 

--- a/playgrounds/core/schema.graphql
+++ b/playgrounds/core/schema.graphql
@@ -2116,6 +2116,9 @@ enum ContentTypeEnum {
 
   """The Type of Content object"""
   POST
+
+  """The Type of Content object"""
+  SPONSOR
 }
 
 """
@@ -2299,7 +2302,7 @@ enum ContentTypesOfTagEnum {
 }
 
 """A block used for editing the site"""
-type CoreAccordion implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreAccordion implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -2434,7 +2437,7 @@ type CoreAccordionAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreAccordionHeading implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreAccordionHeading implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -2554,7 +2557,7 @@ type CoreAccordionHeadingAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreAccordionItem implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreAccordionItem implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -2653,7 +2656,7 @@ type CoreAccordionItemAttributes {
 }
 
 """A block used for editing the site"""
-type CoreAccordionPanel implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreAccordionPanel implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -2757,7 +2760,7 @@ type CoreAccordionPanelAttributes {
 }
 
 """A block used for editing the site"""
-type CoreArchives implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreArchives implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -2871,7 +2874,7 @@ type CoreArchivesAttributes {
 }
 
 """A block used for editing the site"""
-type CoreAudio implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreAudio implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -2976,7 +2979,7 @@ type CoreAudioAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreAvatar implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreAvatar implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -3065,7 +3068,7 @@ type CoreAvatarAttributes {
 }
 
 """A block used for editing the site"""
-type CoreBlock implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreBlock implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -3124,7 +3127,7 @@ type CoreBlockAttributes {
 }
 
 """A block used for editing the site"""
-type CoreButton implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreButton implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -3279,7 +3282,7 @@ type CoreButtonAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreButtons implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreButtons implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -3384,7 +3387,7 @@ type CoreButtonsAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreCalendar implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCalendar implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -3478,7 +3481,7 @@ type CoreCalendarAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCategories implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCategories implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -3612,7 +3615,7 @@ type CoreCategoriesAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCode implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCode implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -3722,7 +3725,7 @@ type CoreCodeAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreColumn implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreColumn implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -3837,7 +3840,7 @@ type CoreColumnAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreColumns implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreColumns implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -3957,7 +3960,7 @@ type CoreColumnsAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreCommentAuthorName implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCommentAuthorName implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -4061,7 +4064,7 @@ type CoreCommentAuthorNameAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCommentContent implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCommentContent implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -4155,7 +4158,7 @@ type CoreCommentContentAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCommentDate implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCommentDate implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -4254,7 +4257,7 @@ type CoreCommentDateAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCommentEditLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCommentEditLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -4348,7 +4351,7 @@ type CoreCommentEditLinkAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCommentReplyLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCommentReplyLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -4437,7 +4440,7 @@ type CoreCommentReplyLinkAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCommentTemplate implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCommentTemplate implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -4516,7 +4519,7 @@ type CoreCommentTemplateAttributes {
 }
 
 """A block used for editing the site"""
-type CoreComments implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreComments implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -4620,7 +4623,7 @@ type CoreCommentsAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCommentsPagination implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCommentsPagination implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -4719,7 +4722,7 @@ type CoreCommentsPaginationAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCommentsPaginationNext implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCommentsPaginationNext implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -4803,7 +4806,7 @@ type CoreCommentsPaginationNextAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCommentsPaginationNumbers implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCommentsPaginationNumbers implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -4882,7 +4885,7 @@ type CoreCommentsPaginationNumbersAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCommentsPaginationPrevious implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCommentsPaginationPrevious implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -4966,7 +4969,7 @@ type CoreCommentsPaginationPreviousAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCommentsTitle implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCommentsTitle implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -5085,7 +5088,7 @@ type CoreCommentsTitleAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCover implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCover implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -5285,7 +5288,7 @@ type CoreCoverAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreDetails implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreDetails implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -5410,7 +5413,7 @@ type CoreDetailsAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreEmbed implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreEmbed implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -5509,7 +5512,7 @@ type CoreEmbedAttributes {
 }
 
 """A block used for editing the site"""
-type CoreFile implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreFile implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -5649,7 +5652,7 @@ type CoreFileAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreFootnotes implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreFootnotes implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -5733,7 +5736,7 @@ type CoreFootnotesAttributes {
 }
 
 """A block used for editing the site"""
-type CoreFreeform implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreFreeform implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -5787,7 +5790,7 @@ type CoreFreeformAttributes {
 }
 
 """A block used for editing the site"""
-type CoreGallery implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreGallery implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -5977,7 +5980,7 @@ type CoreGalleryAttributesImages {
 }
 
 """A block used for editing the site"""
-type CoreGroup implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreGroup implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -6097,7 +6100,7 @@ type CoreGroupAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreHeading implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreHeading implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -6227,7 +6230,7 @@ type CoreHeadingAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreHomeLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreHomeLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -6301,7 +6304,7 @@ type CoreHomeLinkAttributes {
 }
 
 """A block used for editing the site"""
-type CoreHtml implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreHtml implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -6355,7 +6358,7 @@ type CoreHtmlAttributes {
 }
 
 """A block used for editing the site"""
-type CoreImage implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreImage implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -6528,7 +6531,7 @@ type CoreImageAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreLatestComments implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreLatestComments implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -6637,7 +6640,7 @@ type CoreLatestCommentsAttributes {
 }
 
 """A block used for editing the site"""
-type CoreLatestPosts implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreLatestPosts implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -6821,7 +6824,7 @@ type CoreLatestPostsAttributes {
 }
 
 """A block used for editing the site"""
-type CoreLegacyWidget implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreLegacyWidget implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -6885,7 +6888,7 @@ type CoreLegacyWidgetAttributes {
 }
 
 """A block used for editing the site"""
-type CoreList implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreList implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -7015,7 +7018,7 @@ type CoreListAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreListItem implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreListItem implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -7120,7 +7123,7 @@ type CoreListItemAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreLoginout implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreLoginout implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -7214,7 +7217,7 @@ type CoreLoginoutAttributes {
 }
 
 """A block used for editing the site"""
-type CoreMath implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreMath implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -7278,7 +7281,7 @@ type CoreMathAttributes {
 }
 
 """A block used for editing the site"""
-type CoreMediaText implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreMediaText implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -7468,7 +7471,7 @@ type CoreMediaTextAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreMissing implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreMissing implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -7532,7 +7535,7 @@ type CoreMissingAttributes {
 }
 
 """A block used for editing the site"""
-type CoreMore implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreMore implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -7591,7 +7594,7 @@ type CoreMoreAttributes {
 }
 
 """A block used for editing the site"""
-type CoreNavigation implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreNavigation implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -7765,7 +7768,7 @@ type CoreNavigationAttributes {
 }
 
 """A block used for editing the site"""
-type CoreNavigationLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreNavigationLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -7884,7 +7887,7 @@ type CoreNavigationLinkAttributes {
 }
 
 """A block used for editing the site"""
-type CoreNavigationSubmenu implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreNavigationSubmenu implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -8003,7 +8006,7 @@ type CoreNavigationSubmenuAttributes {
 }
 
 """A block used for editing the site"""
-type CoreNextpage implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreNextpage implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -8052,7 +8055,7 @@ type CoreNextpageAttributes {
 }
 
 """A block used for editing the site"""
-type CorePageList implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePageList implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -8151,7 +8154,7 @@ type CorePageListAttributes {
 }
 
 """A block used for editing the site"""
-type CorePageListItem implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePageListItem implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -8230,7 +8233,7 @@ type CorePageListItemAttributes {
 }
 
 """A block used for editing the site"""
-type CoreParagraph implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreParagraph implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -8355,7 +8358,7 @@ type CoreParagraphAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CorePattern implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePattern implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -8414,7 +8417,7 @@ type CorePatternAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostAuthor implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostAuthor implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -8538,7 +8541,7 @@ type CorePostAuthorAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostAuthorBiography implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostAuthorBiography implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -8632,7 +8635,7 @@ type CorePostAuthorBiographyAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostAuthorName implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostAuthorName implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -8736,7 +8739,7 @@ type CorePostAuthorNameAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostComments implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostComments implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -8825,7 +8828,7 @@ type CorePostCommentsAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostCommentsCount implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostCommentsCount implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -8919,7 +8922,7 @@ type CorePostCommentsCountAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostCommentsForm implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostCommentsForm implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -9008,7 +9011,7 @@ type CorePostCommentsFormAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostCommentsLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostCommentsLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -9092,7 +9095,7 @@ type CorePostCommentsLinkAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostContent implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostContent implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -9196,7 +9199,7 @@ type CorePostContentAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostDate implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostDate implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -9305,7 +9308,7 @@ type CorePostDateAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostExcerpt implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostExcerpt implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -9414,7 +9417,7 @@ type CorePostExcerptAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostFeaturedImage implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostFeaturedImage implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -9553,7 +9556,7 @@ type CorePostFeaturedImageAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostNavigationLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostNavigationLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -9667,7 +9670,7 @@ type CorePostNavigationLinkAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostTemplate implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostTemplate implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -9766,7 +9769,7 @@ type CorePostTemplateAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostTerms implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostTerms implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -9960,7 +9963,7 @@ type CorePostTermsToTermNodeConnectionPageInfo implements PageInfo & TermNodeCon
 }
 
 """A block used for editing the site"""
-type CorePostTimeToRead implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostTimeToRead implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -10069,7 +10072,7 @@ type CorePostTimeToReadAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostTitle implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostTitle implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -10193,7 +10196,7 @@ type CorePostTitleAttributes {
 }
 
 """A block used for editing the site"""
-type CorePreformatted implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePreformatted implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -10293,7 +10296,7 @@ type CorePreformattedAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CorePullquote implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePullquote implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -10408,7 +10411,7 @@ type CorePullquoteAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreQuery implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreQuery implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -10497,7 +10500,7 @@ type CoreQueryAttributes {
 }
 
 """A block used for editing the site"""
-type CoreQueryNoResults implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreQueryNoResults implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -10586,7 +10589,7 @@ type CoreQueryNoResultsAttributes {
 }
 
 """A block used for editing the site"""
-type CoreQueryPagination implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreQueryPagination implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -10690,7 +10693,7 @@ type CoreQueryPaginationAttributes {
 }
 
 """A block used for editing the site"""
-type CoreQueryPaginationNext implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreQueryPaginationNext implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -10774,7 +10777,7 @@ type CoreQueryPaginationNextAttributes {
 }
 
 """A block used for editing the site"""
-type CoreQueryPaginationNumbers implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreQueryPaginationNumbers implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -10858,7 +10861,7 @@ type CoreQueryPaginationNumbersAttributes {
 }
 
 """A block used for editing the site"""
-type CoreQueryPaginationPrevious implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreQueryPaginationPrevious implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -10942,7 +10945,7 @@ type CoreQueryPaginationPreviousAttributes {
 }
 
 """A block used for editing the site"""
-type CoreQueryTitle implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreQueryTitle implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -11066,7 +11069,7 @@ type CoreQueryTitleAttributes {
 }
 
 """A block used for editing the site"""
-type CoreQueryTotal implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreQueryTotal implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -11165,7 +11168,7 @@ type CoreQueryTotalAttributes {
 }
 
 """A block used for editing the site"""
-type CoreQuote implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreQuote implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -11290,7 +11293,7 @@ type CoreQuoteAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreReadMore implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreReadMore implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -11389,7 +11392,7 @@ type CoreReadMoreAttributes {
 }
 
 """A block used for editing the site"""
-type CoreRss implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreRss implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -11523,7 +11526,7 @@ type CoreRssAttributes {
 }
 
 """A block used for editing the site"""
-type CoreSearch implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreSearch implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -11667,7 +11670,7 @@ type CoreSearchAttributes {
 }
 
 """A block used for editing the site"""
-type CoreSeparator implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreSeparator implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -11762,7 +11765,7 @@ type CoreSeparatorAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreShortcode implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreShortcode implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -11816,7 +11819,7 @@ type CoreShortcodeAttributes {
 }
 
 """A block used for editing the site"""
-type CoreSiteLogo implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreSiteLogo implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -11900,7 +11903,7 @@ type CoreSiteLogoAttributes {
 }
 
 """A block used for editing the site"""
-type CoreSiteTagline implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreSiteTagline implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -12009,7 +12012,7 @@ type CoreSiteTaglineAttributes {
 }
 
 """A block used for editing the site"""
-type CoreSiteTitle implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreSiteTitle implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -12128,7 +12131,7 @@ type CoreSiteTitleAttributes {
 }
 
 """A block used for editing the site"""
-type CoreSocialLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreSocialLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -12202,7 +12205,7 @@ type CoreSocialLinkAttributes {
 }
 
 """A block used for editing the site"""
-type CoreSocialLinks implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreSocialLinks implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -12337,7 +12340,7 @@ type CoreSocialLinksAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreSpacer implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreSpacer implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -12412,7 +12415,7 @@ type CoreSpacerAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreTable implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreTable implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -12672,7 +12675,7 @@ type CoreTableAttributesHeadCells {
 }
 
 """A block used for editing the site"""
-type CoreTagCloud implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreTagCloud implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -12771,7 +12774,7 @@ type CoreTagCloudAttributes {
 }
 
 """A block used for editing the site"""
-type CoreTemplatePart implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreTemplatePart implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -12850,7 +12853,7 @@ type CoreTemplatePartAttributes {
 }
 
 """A block used for editing the site"""
-type CoreTermCount implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreTermCount implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -12944,7 +12947,7 @@ type CoreTermCountAttributes {
 }
 
 """A block used for editing the site"""
-type CoreTermDescription implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreTermDescription implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -13038,7 +13041,7 @@ type CoreTermDescriptionAttributes {
 }
 
 """A block used for editing the site"""
-type CoreTermName implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreTermName implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -13147,7 +13150,7 @@ type CoreTermNameAttributes {
 }
 
 """A block used for editing the site"""
-type CoreTermTemplate implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreTermTemplate implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -13246,7 +13249,7 @@ type CoreTermTemplateAttributes {
 }
 
 """A block used for editing the site"""
-type CoreTermsQuery implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreTermsQuery implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -13320,7 +13323,7 @@ type CoreTermsQueryAttributes {
 }
 
 """A block used for editing the site"""
-type CoreTextColumns implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreTextColumns implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -13399,7 +13402,7 @@ type CoreTextColumnsAttributesContent {
 }
 
 """A block used for editing the site"""
-type CoreVerse implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreVerse implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -13504,7 +13507,7 @@ type CoreVerseAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreVideo implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreVideo implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -13634,7 +13637,7 @@ type CoreVideoAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreWidgetGroup implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreWidgetGroup implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -14099,6 +14102,53 @@ type CreatePostPayload {
   post: Post
 }
 
+"""Input for the createSponsor mutation."""
+input CreateSponsorInput {
+  """
+  This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions.
+  """
+  clientMutationId: String
+
+  """The content of the object"""
+  content: String
+
+  """
+  The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17 
+  """
+  date: String
+
+  """The excerpt of the object"""
+  excerpt: String
+
+  """
+  A field used for ordering posts. This is typically used with nav menu items or for special ordering of hierarchical content types.
+  """
+  menuOrder: Int
+
+  """The password used to protect the content of the object"""
+  password: String
+
+  """The slug of the object"""
+  slug: String
+
+  """The status of the object"""
+  status: PostStatusEnum
+
+  """The title of the object"""
+  title: String
+}
+
+"""The payload for the createSponsor mutation."""
+type CreateSponsorPayload {
+  """
+  If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
+  """
+  clientMutationId: String
+
+  """The Post object mutation type."""
+  sponsor: Sponsor
+}
+
 """Input for the createTag mutation."""
 input CreateTagInput {
   """The slug that the post_tag will be an alias of"""
@@ -14508,6 +14558,39 @@ type DeletePostPayload {
 
   """The object before it was deleted"""
   post: Post
+}
+
+"""Input for the deleteSponsor mutation."""
+input DeleteSponsorInput {
+  """
+  This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions.
+  """
+  clientMutationId: String
+
+  """
+  Whether the object should be force deleted instead of being moved to the trash
+  """
+  forceDelete: Boolean
+
+  """The ID of the Sponsor to delete"""
+  id: ID!
+
+  """Override the edit lock when another user is editing the post"""
+  ignoreEditLock: Boolean
+}
+
+"""The payload for the deleteSponsor mutation."""
+type DeleteSponsorPayload {
+  """
+  If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
+  """
+  clientMutationId: String
+
+  """The ID of the deleted object"""
+  deletedId: ID
+
+  """The object before it was deleted"""
+  sponsor: Sponsor
 }
 
 """Input for the deleteTag mutation."""
@@ -18428,7 +18511,7 @@ enum MenuItemNodeIdTypeEnum {
 }
 
 """Deprecated in favor of MenuItemLinkable Interface"""
-union MenuItemObjectUnion = Category | Event | EventCategory | Page | Post | PostFormat | Tag
+union MenuItemObjectUnion = Category | Event | EventCategory | Page | Post | PostFormat | Sponsor | Tag
 
 """Connection between the MenuItem type and the Menu type"""
 type MenuItemToMenuConnectionEdge implements Edge & MenuConnectionEdge & OneToOneConnection {
@@ -19085,6 +19168,15 @@ type NodeWithRevisionsToContentNodeConnectionEdge implements ContentNodeConnecti
 
   """The node of the connection, without the edges"""
   node: ContentNode!
+}
+
+"""Node that has Sponsor content blocks associated with it"""
+interface NodeWithSponsorEditorBlocks implements NodeWithEditorBlocks {
+  """List of Sponsor editor blocks"""
+  editorBlocks(
+    """Returns the list of blocks as a flat list if true"""
+    flat: Boolean
+  ): [SponsorEditorBlock]
 }
 
 """
@@ -22576,6 +22668,12 @@ type RootMutation {
     input: CreatePostFormatInput!
   ): CreatePostFormatPayload
 
+  """The createSponsor mutation"""
+  createSponsor(
+    """Input for the createSponsor mutation"""
+    input: CreateSponsorInput!
+  ): CreateSponsorPayload
+
   """The createTag mutation"""
   createTag(
     """Input for the createTag mutation"""
@@ -22635,6 +22733,12 @@ type RootMutation {
     """Input for the deletePostFormat mutation"""
     input: DeletePostFormatInput!
   ): DeletePostFormatPayload
+
+  """The deleteSponsor mutation"""
+  deleteSponsor(
+    """Input for the deleteSponsor mutation"""
+    input: DeleteSponsorInput!
+  ): DeleteSponsorPayload
 
   """The deleteTag mutation"""
   deleteTag(
@@ -22769,6 +22873,12 @@ type RootMutation {
     """Input for the updateSettings mutation"""
     input: UpdateSettingsInput!
   ): UpdateSettingsPayload
+
+  """The updateSponsor mutation"""
+  updateSponsor(
+    """Input for the updateSponsor mutation"""
+    input: UpdateSponsorInput!
+  ): UpdateSponsorPayload
 
   """The updateTag mutation"""
   updateTag(
@@ -23382,6 +23492,59 @@ type RootQuery {
 
   """Returns seo site data"""
   seo: SEOConfig
+
+  """An object of the Sponsor Type. """
+  sponsor(
+    """
+    Whether to return the Preview Node instead of the Published Node. When the ID of a Node is provided along with asPreview being set to true, the preview node with un-published changes will be returned instead of the published node. If no preview node exists or the requester doesn't have proper capabilities to preview, no node will be returned. If the ID provided is a URI and has a preview query arg, it will be used as a fallback if the "asPreview" argument is not explicitly provided as an argument.
+    """
+    asPreview: Boolean
+
+    """The globally unique identifier of the object."""
+    id: ID!
+
+    """Type of unique identifier to fetch by. Default is Global ID"""
+    idType: SponsorIdType
+  ): Sponsor
+
+  """A Sponsor object"""
+  sponsorBy(
+    """Get the Sponsor object by its global ID"""
+    id: ID
+
+    """
+    Get the Sponsor by its slug (only available for non-hierarchical types)
+    """
+    slug: String
+
+    """Get the Sponsor by its database ID"""
+    sponsorId: Int
+
+    """Get the Sponsor by its uri"""
+    uri: String
+  ): Sponsor @deprecated(reason: "Deprecated in favor of using the single entry point for this type with ID and IDType fields. For example, instead of postBy( id: &quot;&quot; ), use post(id: &quot;&quot; idType: &quot;&quot;)")
+
+  """Connection between the RootQuery type and the Sponsor type"""
+  sponsors(
+    """
+    Cursor used along with the "first" argument to reference where in the dataset to get data
+    """
+    after: String
+
+    """
+    Cursor used along with the "last" argument to reference where in the dataset to get data
+    """
+    before: String
+
+    """The number of items to return after the referenced "after" cursor"""
+    first: Int
+
+    """The number of items to return before the referenced "before" cursor"""
+    last: Int
+
+    """Arguments for filtering the connection"""
+    where: RootQueryToSponsorConnectionWhereArgs
+  ): RootQueryToSponsorConnection
 
   """A 0bject"""
   tag(
@@ -25059,6 +25222,105 @@ input RootQueryToRevisionsConnectionWhereArgs {
   title: String
 }
 
+"""Connection between the RootQuery type and the Sponsor type"""
+type RootQueryToSponsorConnection implements Connection & SponsorConnection {
+  """Edges for the RootQueryToSponsorConnection connection"""
+  edges: [RootQueryToSponsorConnectionEdge!]!
+
+  """The nodes of the connection, without the edges"""
+  nodes: [Sponsor!]!
+
+  """Information about pagination in a connection."""
+  pageInfo: RootQueryToSponsorConnectionPageInfo!
+}
+
+"""An edge in a connection"""
+type RootQueryToSponsorConnectionEdge implements Edge & SponsorConnectionEdge {
+  """A cursor for use in pagination"""
+  cursor: String
+
+  """The item at the end of the edge"""
+  node: Sponsor!
+}
+
+"""
+Pagination metadata specific to &quot;RootQueryToSponsorConnection&quot; collections. Provides cursors and flags for navigating through sets of RootQueryToSponsorConnection Nodes.
+"""
+type RootQueryToSponsorConnectionPageInfo implements PageInfo & SponsorConnectionPageInfo & WPPageInfo {
+  """When paginating forwards, the cursor to continue."""
+  endCursor: String
+
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+
+  """Raw schema for page"""
+  seo: SEOPostTypePageInfo
+
+  """When paginating backwards, the cursor to continue."""
+  startCursor: String
+}
+
+"""Arguments for filtering the RootQueryToSponsorConnection connection"""
+input RootQueryToSponsorConnectionWhereArgs {
+  """Filter the connection based on dates"""
+  dateQuery: DateQueryInput
+
+  """
+  True for objects with passwords; False for objects without passwords; null for all objects with or without passwords
+  """
+  hasPassword: Boolean
+
+  """Specific database ID of the object"""
+  id: Int
+
+  """Array of IDs for the objects to retrieve"""
+  in: [ID]
+
+  """Get objects with a specific mimeType property"""
+  mimeType: MimeTypeEnum
+
+  """Slug / post_name of the object"""
+  name: String
+
+  """Specify objects to retrieve. Use slugs"""
+  nameIn: [String]
+
+  """
+  Specify IDs NOT to retrieve. If this is used in the same query as "in", it will be ignored
+  """
+  notIn: [ID]
+
+  """What parameter to use to order the objects by."""
+  orderby: [PostObjectsConnectionOrderbyInput]
+
+  """Use ID to return only children. Use 0 to return only top-level items"""
+  parent: ID
+
+  """Specify objects whose parent is in an array"""
+  parentIn: [ID]
+
+  """Specify posts whose parent is not in an array"""
+  parentNotIn: [ID]
+
+  """Show posts with a specific password."""
+  password: String
+
+  """Show Posts based on a keyword search"""
+  search: String
+
+  """Retrieve posts where post status is in an array."""
+  stati: [PostStatusEnum]
+
+  """Show posts with a specific status."""
+  status: PostStatusEnum
+
+  """Title of the object"""
+  title: String
+}
+
 """Connection between the RootQuery type and the tag type"""
 type RootQueryToTagConnection implements Connection & TagConnection {
   """Edges for the RootQueryToTagConnection connection"""
@@ -25679,6 +25941,9 @@ type SEOContentTypes {
 
   """"""
   post: SEOContentType
+
+  """"""
+  sponsor: SEOContentType
 }
 
 """The Yoast SEO meta data"""
@@ -26165,6 +26430,515 @@ type SiteTokenClientOptions implements LoginClientOptions {
 type SiteTokenLoginOptions implements LoginOptions {
   """Whether to set a WordPress authentication cookie on successful login."""
   useAuthenticationCookie: Boolean
+}
+
+"""The Sponsor type"""
+type Sponsor implements ContentNode & DatabaseIdentifier & MenuItemLinkable & Node & NodeWithContentEditor & NodeWithEditorBlocks & NodeWithExcerpt & NodeWithFeaturedImage & NodeWithRevisions & NodeWithSponsorEditorBlocks & NodeWithTemplate & NodeWithTitle & Previewable & UniformResourceIdentifiable {
+  """The ancestors of the content node."""
+  ancestors(
+    """
+    Cursor used along with the "first" argument to reference where in the dataset to get data
+    """
+    after: String
+
+    """
+    Cursor used along with the "last" argument to reference where in the dataset to get data
+    """
+    before: String
+
+    """The number of items to return after the referenced "after" cursor"""
+    first: Int
+
+    """The number of items to return before the referenced "before" cursor"""
+    last: Int
+  ): SponsorToSponsorConnection @deprecated(reason: "This content type is not hierarchical and typically will not have ancestors")
+
+  """"""
+  conditionalTags: ConditionalTags @deprecated(reason: "Deprecated in favor of using Next.js pages")
+
+  """The content of the post."""
+  content(
+    """Format of the field output"""
+    format: PostObjectFieldFormatEnum
+  ): String
+
+  """Connection between the ContentNode type and the ContentType type"""
+  contentType: ContentNodeToContentTypeConnectionEdge
+
+  """The name of the Content Type the node belongs to"""
+  contentTypeName: String!
+
+  """The unique identifier stored in the database"""
+  databaseId: Int!
+
+  """Post publishing date."""
+  date: String
+
+  """The publishing date set in GMT."""
+  dateGmt: String
+
+  """The desired slug of the post"""
+  desiredSlug: String
+
+  """
+  If a user has edited the node within the past 15 seconds, this will return the user that last edited. Null if the edit lock doesn&#039;t exist or is greater than 15 seconds
+  """
+  editingLockedBy: ContentNodeToEditLockConnectionEdge
+
+  """List of Sponsor editor blocks"""
+  editorBlocks(
+    """Returns the list of blocks as a flat list if true"""
+    flat: Boolean
+  ): [SponsorEditorBlock]
+
+  """The RSS enclosure for the object"""
+  enclosure: String
+
+  """Connection between the ContentNode type and the EnqueuedScript type"""
+  enqueuedScripts(
+    """
+    Cursor used along with the "first" argument to reference where in the dataset to get data
+    """
+    after: String
+
+    """
+    Cursor used along with the "last" argument to reference where in the dataset to get data
+    """
+    before: String
+
+    """The number of items to return after the referenced "after" cursor"""
+    first: Int
+
+    """The number of items to return before the referenced "before" cursor"""
+    last: Int
+  ): ContentNodeToEnqueuedScriptConnection
+
+  """
+  Connection between the ContentNode type and the EnqueuedStylesheet type
+  """
+  enqueuedStylesheets(
+    """
+    Cursor used along with the "first" argument to reference where in the dataset to get data
+    """
+    after: String
+
+    """
+    Cursor used along with the "last" argument to reference where in the dataset to get data
+    """
+    before: String
+
+    """The number of items to return after the referenced "after" cursor"""
+    first: Int
+
+    """The number of items to return before the referenced "before" cursor"""
+    last: Int
+  ): ContentNodeToEnqueuedStylesheetConnection
+
+  """The excerpt of the post."""
+  excerpt(
+    """Format of the field output"""
+    format: PostObjectFieldFormatEnum
+  ): String
+
+  """
+  Connection between the NodeWithFeaturedImage type and the MediaItem type
+  """
+  featuredImage: NodeWithFeaturedImageToMediaItemConnectionEdge
+
+  """
+  The database identifier for the featured image node assigned to the content node
+  """
+  featuredImageDatabaseId: Int
+
+  """Globally unique ID of the featured image assigned to the node"""
+  featuredImageId: ID
+
+  """
+  The global unique identifier for this post. This currently matches the value stored in WP_Post-&gt;guid and the guid column in the &quot;post_objects&quot; database table.
+  """
+  guid: String
+
+  """Whether the sponsor object is password protected."""
+  hasPassword: Boolean
+
+  """The globally unique identifier of the sponsor object."""
+  id: ID!
+
+  """Whether the node is a Comment"""
+  isComment: Boolean!
+
+  """Whether the node is a Content Node"""
+  isContentNode: Boolean!
+
+  """Whether the node represents the front page."""
+  isFrontPage: Boolean!
+
+  """Whether  the node represents the blog page."""
+  isPostsPage: Boolean!
+
+  """Whether the object is a node in the preview state"""
+  isPreview: Boolean
+
+  """Whether the object is restricted from the current viewer"""
+  isRestricted: Boolean
+
+  """True if the node is a revision of another node"""
+  isRevision: Boolean
+
+  """Whether the node is a Term"""
+  isTermNode: Boolean!
+
+  """The user that most recently edited the node"""
+  lastEditedBy: ContentNodeToEditLastConnectionEdge
+
+  """The permalink of the post"""
+  link: String
+
+  """
+  The local modified time for a post. If a post was recently updated the modified field will change to match the corresponding time.
+  """
+  modified: String
+
+  """
+  The GMT modified time for a post. If a post was recently updated the modified field will change to match the corresponding time in GMT.
+  """
+  modifiedGmt: String
+
+  """The parent of the content node."""
+  parent: SponsorToParentConnectionEdge @deprecated(reason: "This content type is not hierarchical and typically will not have a parent")
+
+  """The password for the sponsor object."""
+  password: String
+
+  """Connection between the Sponsor type and the Sponsor type"""
+  preview: SponsorToPreviewConnectionEdge
+
+  """The database id of the preview node"""
+  previewRevisionDatabaseId: Int
+
+  """Whether the object is a node in the preview state"""
+  previewRevisionId: ID
+
+  """
+  If the current node is a revision, this field exposes the node this is a revision of. Returns null if the node is not a revision of another node.
+  """
+  revisionOf: NodeWithRevisionsToContentNodeConnectionEdge
+
+  """Connection between the Sponsor type and the Sponsor type"""
+  revisions(
+    """
+    Cursor used along with the "first" argument to reference where in the dataset to get data
+    """
+    after: String
+
+    """
+    Cursor used along with the "last" argument to reference where in the dataset to get data
+    """
+    before: String
+
+    """The number of items to return after the referenced "after" cursor"""
+    first: Int
+
+    """The number of items to return before the referenced "before" cursor"""
+    last: Int
+
+    """Arguments for filtering the connection"""
+    where: SponsorToRevisionConnectionWhereArgs
+  ): SponsorToRevisionConnection
+
+  """The Yoast SEO data of the ContentNode"""
+  seo: PostTypeSEO
+
+  """
+  The uri slug for the post. This is equivalent to the WP_Post-&gt;post_name field and the post_name column in the database for the &quot;post_objects&quot; table.
+  """
+  slug: String
+
+  """The id field matches the WP_Post-&gt;ID field."""
+  sponsorId: Int! @deprecated(reason: "Deprecated in favor of the databaseId field")
+
+  """The current status of the object"""
+  status: String
+
+  """The template assigned to the node"""
+  template: ContentTemplate
+
+  """"""
+  templates: [String]
+
+  """
+  The title of the post. This is currently just the raw title. An amendment to support rendered title needs to be made.
+  """
+  title(
+    """Format of the field output"""
+    format: PostObjectFieldFormatEnum
+  ): String
+
+  """The unique resource identifier path"""
+  uri: String
+}
+
+"""
+A paginated collection of Sponsor Nodes, Supports cursor-based pagination and filtering to efficiently retrieve sets of Sponsor Nodes
+"""
+interface SponsorConnection implements Connection {
+  """
+  A list of edges (relational context) between RootQuery and connected Sponsor Nodes
+  """
+  edges: [SponsorConnectionEdge!]!
+
+  """A list of connected Sponsor Nodes"""
+  nodes: [Sponsor!]!
+
+  """Information about pagination in a connection."""
+  pageInfo: SponsorConnectionPageInfo!
+}
+
+"""
+Represents a connection to a Sponsor. Contains both the Sponsor Node and metadata about the relationship.
+"""
+interface SponsorConnectionEdge implements Edge {
+  """
+  Opaque reference to the nodes position in the connection. Value can be used with pagination args.
+  """
+  cursor: String
+
+  """The connected Sponsor Node"""
+  node: Sponsor!
+}
+
+"""
+Pagination metadata specific to &quot;SponsorConnectionEdge&quot; collections. Provides cursors and flags for navigating through sets of &quot;SponsorConnectionEdge&quot; Nodes.
+"""
+interface SponsorConnectionPageInfo implements PageInfo & WPPageInfo {
+  """When paginating forwards, the cursor to continue."""
+  endCursor: String
+
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+
+  """Raw schema for page"""
+  seo: SEOPostTypePageInfo
+
+  """When paginating backwards, the cursor to continue."""
+  startCursor: String
+}
+
+"""EditorBlock Interface for Sponsor Block Type"""
+interface SponsorEditorBlock implements EditorBlock {
+  """The API version of the Gutenberg Block"""
+  apiVersion: Int
+
+  """The name of the category the Block belongs to"""
+  blockEditorCategoryName: String
+
+  """The id of the Block"""
+  clientId: String
+
+  """CSS Classnames to apply to the block"""
+  cssClassNames: [String]
+
+  """The inner blocks of the Block"""
+  innerBlocks: [EditorBlock]
+
+  """Whether the block is Dynamic (server rendered)"""
+  isDynamic: Boolean!
+
+  """The name of the Block"""
+  name: String
+
+  """The parent id of the Block"""
+  parentClientId: String
+
+  """The rendered HTML for the block"""
+  renderedHtml: String
+
+  """The (GraphQL) type of the block"""
+  type: String
+}
+
+"""
+Identifier types for retrieving a specific Sponsor. Specifies which unique attribute is used to find an exact Sponsor.
+"""
+enum SponsorIdType {
+  """Identify a resource by the Database ID."""
+  DATABASE_ID
+
+  """Identify a resource by the (hashed) Global ID."""
+  ID
+
+  """
+  Identify a resource by the slug. Available to non-hierarchcial Types where the slug is a unique identifier.
+  """
+  SLUG
+
+  """Identify a resource by the URI."""
+  URI
+}
+
+"""Connection between the Sponsor type and the Sponsor type"""
+type SponsorToParentConnectionEdge implements Edge & OneToOneConnection & SponsorConnectionEdge {
+  """
+  Opaque reference to the nodes position in the connection. Value can be used with pagination args.
+  """
+  cursor: String
+
+  """The node of the connection, without the edges"""
+  node: Sponsor! @deprecated(reason: "This content type is not hierarchical and typically will not have a parent")
+}
+
+"""Connection between the Sponsor type and the Sponsor type"""
+type SponsorToPreviewConnectionEdge implements Edge & OneToOneConnection & SponsorConnectionEdge {
+  """
+  Opaque reference to the nodes position in the connection. Value can be used with pagination args.
+  """
+  cursor: String
+
+  """The node of the connection, without the edges"""
+  node: Sponsor!
+}
+
+"""Connection between the Sponsor type and the Sponsor type"""
+type SponsorToRevisionConnection implements Connection & SponsorConnection {
+  """Edges for the SponsorToRevisionConnection connection"""
+  edges: [SponsorToRevisionConnectionEdge!]!
+
+  """The nodes of the connection, without the edges"""
+  nodes: [Sponsor!]!
+
+  """Information about pagination in a connection."""
+  pageInfo: SponsorToRevisionConnectionPageInfo!
+}
+
+"""An edge in a connection"""
+type SponsorToRevisionConnectionEdge implements Edge & SponsorConnectionEdge {
+  """A cursor for use in pagination"""
+  cursor: String
+
+  """The item at the end of the edge"""
+  node: Sponsor!
+}
+
+"""
+Pagination metadata specific to &quot;SponsorToRevisionConnection&quot; collections. Provides cursors and flags for navigating through sets of SponsorToRevisionConnection Nodes.
+"""
+type SponsorToRevisionConnectionPageInfo implements PageInfo & SponsorConnectionPageInfo & WPPageInfo {
+  """When paginating forwards, the cursor to continue."""
+  endCursor: String
+
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+
+  """Raw schema for page"""
+  seo: SEOPostTypePageInfo
+
+  """When paginating backwards, the cursor to continue."""
+  startCursor: String
+}
+
+"""Arguments for filtering the SponsorToRevisionConnection connection"""
+input SponsorToRevisionConnectionWhereArgs {
+  """Filter the connection based on dates"""
+  dateQuery: DateQueryInput
+
+  """
+  True for objects with passwords; False for objects without passwords; null for all objects with or without passwords
+  """
+  hasPassword: Boolean
+
+  """Specific database ID of the object"""
+  id: Int
+
+  """Array of IDs for the objects to retrieve"""
+  in: [ID]
+
+  """Get objects with a specific mimeType property"""
+  mimeType: MimeTypeEnum
+
+  """Slug / post_name of the object"""
+  name: String
+
+  """Specify objects to retrieve. Use slugs"""
+  nameIn: [String]
+
+  """
+  Specify IDs NOT to retrieve. If this is used in the same query as "in", it will be ignored
+  """
+  notIn: [ID]
+
+  """What parameter to use to order the objects by."""
+  orderby: [PostObjectsConnectionOrderbyInput]
+
+  """Use ID to return only children. Use 0 to return only top-level items"""
+  parent: ID
+
+  """Specify objects whose parent is in an array"""
+  parentIn: [ID]
+
+  """Specify posts whose parent is not in an array"""
+  parentNotIn: [ID]
+
+  """Show posts with a specific password."""
+  password: String
+
+  """Show Posts based on a keyword search"""
+  search: String
+
+  """Retrieve posts where post status is in an array."""
+  stati: [PostStatusEnum]
+
+  """Show posts with a specific status."""
+  status: PostStatusEnum
+
+  """Title of the object"""
+  title: String
+}
+
+"""Connection between the Sponsor type and the Sponsor type"""
+type SponsorToSponsorConnection implements Connection & SponsorConnection {
+  """Edges for the SponsorToSponsorConnection connection"""
+  edges: [SponsorToSponsorConnectionEdge!]!
+
+  """The nodes of the connection, without the edges"""
+  nodes: [Sponsor!]!
+
+  """Information about pagination in a connection."""
+  pageInfo: SponsorToSponsorConnectionPageInfo!
+}
+
+"""An edge in a connection"""
+type SponsorToSponsorConnectionEdge implements Edge & SponsorConnectionEdge {
+  """A cursor for use in pagination"""
+  cursor: String @deprecated(reason: "This content type is not hierarchical and typically will not have ancestors")
+
+  """The item at the end of the edge"""
+  node: Sponsor! @deprecated(reason: "This content type is not hierarchical and typically will not have ancestors")
+}
+
+"""
+Pagination metadata specific to &quot;SponsorToSponsorConnection&quot; collections. Provides cursors and flags for navigating through sets of SponsorToSponsorConnection Nodes.
+"""
+type SponsorToSponsorConnectionPageInfo implements PageInfo & SponsorConnectionPageInfo & WPPageInfo {
+  """When paginating forwards, the cursor to continue."""
+  endCursor: String
+
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+
+  """Raw schema for page"""
+  seo: SEOPostTypePageInfo
+
+  """When paginating backwards, the cursor to continue."""
+  startCursor: String
 }
 
 """
@@ -27935,6 +28709,59 @@ type UpdateSettingsPayload {
   writingSettings: WritingSettings
 }
 
+"""Input for the updateSponsor mutation."""
+input UpdateSponsorInput {
+  """
+  This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions.
+  """
+  clientMutationId: String
+
+  """The content of the object"""
+  content: String
+
+  """
+  The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17 
+  """
+  date: String
+
+  """The excerpt of the object"""
+  excerpt: String
+
+  """The ID of the Sponsor object"""
+  id: ID!
+
+  """Override the edit lock when another user is editing the post"""
+  ignoreEditLock: Boolean
+
+  """
+  A field used for ordering posts. This is typically used with nav menu items or for special ordering of hierarchical content types.
+  """
+  menuOrder: Int
+
+  """The password used to protect the content of the object"""
+  password: String
+
+  """The slug of the object"""
+  slug: String
+
+  """The status of the object"""
+  status: PostStatusEnum
+
+  """The title of the object"""
+  title: String
+}
+
+"""The payload for the updateSponsor mutation."""
+type UpdateSponsorPayload {
+  """
+  If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
+  """
+  clientMutationId: String
+
+  """The Post object mutation type."""
+  sponsor: Sponsor
+}
+
 """Input for the updateTag mutation."""
 input UpdateTagInput {
   """The slug that the post_tag will be an alias of"""
@@ -29361,7 +30188,7 @@ type WritingSettings {
 }
 
 """A block used for editing the site"""
-type YoastFaqBlock implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type YoastFaqBlock implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -29425,7 +30252,7 @@ type YoastFaqBlockAttributes {
 }
 
 """A block used for editing the site"""
-type YoastHowToBlock implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type YoastHowToBlock implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -29534,7 +30361,7 @@ type YoastHowToBlockAttributes {
 }
 
 """A block used for editing the site"""
-type YoastSeoBreadcrumbs implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type YoastSeoBreadcrumbs implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 

--- a/playgrounds/full/app/pages/index.vue
+++ b/playgrounds/full/app/pages/index.vue
@@ -6,6 +6,11 @@ const { data: posts, pending, refresh, clear } = await usePosts(() => ({
   orderField: orderField.value,
   order: order.value
 }))
+
+// `useSponsors` is auto-generated — no fragment or query file was written
+// by hand. Registering the Sponsor CPT on the WordPress backend is enough
+// for WPNuxt to emit this composable from the downloaded schema.
+const { data: sponsors } = await useSponsors({ first: 8 })
 </script>
 
 <template>
@@ -35,6 +40,43 @@ const { data: posts, pending, refresh, clear } = await usePosts(() => ({
             </template>
           </UBlogPost>
         </UBlogPosts>
+
+        <section v-if="sponsors?.length" class="mt-16">
+          <div class="mb-6">
+            <h2 class="text-xl font-semibold">
+              Sponsors
+            </h2>
+            <p class="text-sm text-muted mt-1">
+              Companies and studios backing the WPNuxt project. Auto-generated via the Sponsor CPT — no hand-written queries.
+            </p>
+          </div>
+          <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+            <div
+              v-for="sponsor in sponsors"
+              :key="sponsor.id"
+              class="rounded-lg border border-default overflow-hidden"
+            >
+              <NuxtImg
+                v-if="sponsor.featuredImage?.node?.relativePath"
+                :src="sponsor.featuredImage.node.relativePath"
+                :alt="sponsor.title ?? ''"
+                class="w-full aspect-video object-cover"
+                width="400"
+                height="225"
+              />
+              <div class="p-4">
+                <h3 class="font-medium">
+                  {{ sponsor.title }}
+                </h3>
+                <div
+                  v-if="sponsor.excerpt"
+                  v-sanitize-html="sponsor.excerpt"
+                  class="text-sm text-muted mt-2"
+                />
+              </div>
+            </div>
+          </div>
+        </section>
       </UPageBody>
     </UPage>
   </UContainer>

--- a/playgrounds/full/blueprint/setup-content.php
+++ b/playgrounds/full/blueprint/setup-content.php
@@ -237,6 +237,13 @@ if ( ! is_wp_error( $menu_id ) ) {
     ]);
 
     wp_update_nav_menu_item( $menu_id, 0, [
+        'menu-item-title'  => 'Sponsors',
+        'menu-item-url'    => home_url( '/sponsors/' ),
+        'menu-item-status' => 'publish',
+        'menu-item-type'   => 'custom',
+    ]);
+
+    wp_update_nav_menu_item( $menu_id, 0, [
         'menu-item-title'  => 'About',
         'menu-item-url'    => home_url( '/about/' ),
         'menu-item-status' => 'publish',
@@ -380,4 +387,53 @@ foreach ( $events as $event_data ) {
     }
 }
 
-echo "Setup complete: created " . count($posts) . " posts, " . count($pages) . " pages, " . count($events) . " events, and navigation menu.\n";
+// ---------------------------------------------------------------------------
+// Create sponsors (simple CPT — demonstrates WPNuxt auto-generation)
+// ---------------------------------------------------------------------------
+$sponsors = [
+    [
+        'title'   => 'Acme Corp',
+        'slug'    => 'acme-corp',
+        'excerpt' => 'Longtime supporter of the Brussels dev community.',
+        'content' => '<!-- wp:paragraph -->
+<p>Acme Corp has proudly sponsored our meetups for three years running. Their commitment to open source goes beyond funding — they regularly host workshops and contribute engineering time to community projects.</p>
+<!-- /wp:paragraph -->',
+    ],
+    [
+        'title'   => 'Contoso Labs',
+        'slug'    => 'contoso-labs',
+        'excerpt' => 'Research-driven engineering studio focused on headless CMS.',
+        'content' => '<!-- wp:paragraph -->
+<p>Contoso Labs builds tooling and platforms for headless WordPress deployments. They are active in the WPGraphQL community and have contributed performance patches back to the upstream plugin.</p>
+<!-- /wp:paragraph -->',
+    ],
+    [
+        'title'   => 'Globex',
+        'slug'    => 'globex',
+        'excerpt' => 'Europe-wide consultancy specialising in Nuxt + WordPress stacks.',
+        'content' => '<!-- wp:paragraph -->
+<p>Globex has helped dozens of teams migrate from monolithic WordPress to a headless WPNuxt stack. Their playbooks on ISR, cache invalidation, and preview mode are widely referenced.</p>
+<!-- /wp:paragraph -->',
+    ],
+    [
+        'title'   => 'Initech',
+        'slug'    => 'initech',
+        'excerpt' => 'Boutique product studio backing open source.',
+        'content' => '<!-- wp:paragraph -->
+<p>Initech sponsors this project and several other small open-source tools. They use WPNuxt to power their own marketing site and contribute patches upstream.</p>
+<!-- /wp:paragraph -->',
+    ],
+];
+
+foreach ( $sponsors as $sponsor_data ) {
+    wp_insert_post([
+        'post_title'   => $sponsor_data['title'],
+        'post_name'    => $sponsor_data['slug'],
+        'post_content' => $sponsor_data['content'],
+        'post_excerpt' => $sponsor_data['excerpt'],
+        'post_status'  => 'publish',
+        'post_type'    => 'sponsor',
+    ]);
+}
+
+echo "Setup complete: created " . count($posts) . " posts, " . count($pages) . " pages, " . count($events) . " events, " . count($sponsors) . " sponsors, and navigation menu.\n";

--- a/playgrounds/full/schema.graphql
+++ b/playgrounds/full/schema.graphql
@@ -2116,6 +2116,9 @@ enum ContentTypeEnum {
 
   """The Type of Content object"""
   POST
+
+  """The Type of Content object"""
+  SPONSOR
 }
 
 """
@@ -2299,7 +2302,7 @@ enum ContentTypesOfTagEnum {
 }
 
 """A block used for editing the site"""
-type CoreAccordion implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreAccordion implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -2434,7 +2437,7 @@ type CoreAccordionAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreAccordionHeading implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreAccordionHeading implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -2554,7 +2557,7 @@ type CoreAccordionHeadingAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreAccordionItem implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreAccordionItem implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -2653,7 +2656,7 @@ type CoreAccordionItemAttributes {
 }
 
 """A block used for editing the site"""
-type CoreAccordionPanel implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreAccordionPanel implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -2757,7 +2760,7 @@ type CoreAccordionPanelAttributes {
 }
 
 """A block used for editing the site"""
-type CoreArchives implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreArchives implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -2871,7 +2874,7 @@ type CoreArchivesAttributes {
 }
 
 """A block used for editing the site"""
-type CoreAudio implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreAudio implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -2976,7 +2979,7 @@ type CoreAudioAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreAvatar implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreAvatar implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -3065,7 +3068,7 @@ type CoreAvatarAttributes {
 }
 
 """A block used for editing the site"""
-type CoreBlock implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreBlock implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -3124,7 +3127,7 @@ type CoreBlockAttributes {
 }
 
 """A block used for editing the site"""
-type CoreButton implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreButton implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -3279,7 +3282,7 @@ type CoreButtonAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreButtons implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreButtons implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -3384,7 +3387,7 @@ type CoreButtonsAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreCalendar implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCalendar implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -3478,7 +3481,7 @@ type CoreCalendarAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCategories implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCategories implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -3612,7 +3615,7 @@ type CoreCategoriesAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCode implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCode implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -3722,7 +3725,7 @@ type CoreCodeAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreColumn implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreColumn implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -3837,7 +3840,7 @@ type CoreColumnAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreColumns implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreColumns implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -3957,7 +3960,7 @@ type CoreColumnsAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreCommentAuthorName implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCommentAuthorName implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -4061,7 +4064,7 @@ type CoreCommentAuthorNameAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCommentContent implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCommentContent implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -4155,7 +4158,7 @@ type CoreCommentContentAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCommentDate implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCommentDate implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -4254,7 +4257,7 @@ type CoreCommentDateAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCommentEditLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCommentEditLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -4348,7 +4351,7 @@ type CoreCommentEditLinkAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCommentReplyLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCommentReplyLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -4437,7 +4440,7 @@ type CoreCommentReplyLinkAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCommentTemplate implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCommentTemplate implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -4516,7 +4519,7 @@ type CoreCommentTemplateAttributes {
 }
 
 """A block used for editing the site"""
-type CoreComments implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreComments implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -4620,7 +4623,7 @@ type CoreCommentsAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCommentsPagination implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCommentsPagination implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -4719,7 +4722,7 @@ type CoreCommentsPaginationAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCommentsPaginationNext implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCommentsPaginationNext implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -4803,7 +4806,7 @@ type CoreCommentsPaginationNextAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCommentsPaginationNumbers implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCommentsPaginationNumbers implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -4882,7 +4885,7 @@ type CoreCommentsPaginationNumbersAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCommentsPaginationPrevious implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCommentsPaginationPrevious implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -4966,7 +4969,7 @@ type CoreCommentsPaginationPreviousAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCommentsTitle implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCommentsTitle implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -5085,7 +5088,7 @@ type CoreCommentsTitleAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCover implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCover implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -5285,7 +5288,7 @@ type CoreCoverAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreDetails implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreDetails implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -5410,7 +5413,7 @@ type CoreDetailsAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreEmbed implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreEmbed implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -5509,7 +5512,7 @@ type CoreEmbedAttributes {
 }
 
 """A block used for editing the site"""
-type CoreFile implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreFile implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -5649,7 +5652,7 @@ type CoreFileAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreFootnotes implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreFootnotes implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -5733,7 +5736,7 @@ type CoreFootnotesAttributes {
 }
 
 """A block used for editing the site"""
-type CoreFreeform implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreFreeform implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -5787,7 +5790,7 @@ type CoreFreeformAttributes {
 }
 
 """A block used for editing the site"""
-type CoreGallery implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreGallery implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -5977,7 +5980,7 @@ type CoreGalleryAttributesImages {
 }
 
 """A block used for editing the site"""
-type CoreGroup implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreGroup implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -6097,7 +6100,7 @@ type CoreGroupAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreHeading implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreHeading implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -6227,7 +6230,7 @@ type CoreHeadingAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreHomeLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreHomeLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -6301,7 +6304,7 @@ type CoreHomeLinkAttributes {
 }
 
 """A block used for editing the site"""
-type CoreHtml implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreHtml implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -6355,7 +6358,7 @@ type CoreHtmlAttributes {
 }
 
 """A block used for editing the site"""
-type CoreImage implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreImage implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -6528,7 +6531,7 @@ type CoreImageAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreLatestComments implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreLatestComments implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -6637,7 +6640,7 @@ type CoreLatestCommentsAttributes {
 }
 
 """A block used for editing the site"""
-type CoreLatestPosts implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreLatestPosts implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -6821,7 +6824,7 @@ type CoreLatestPostsAttributes {
 }
 
 """A block used for editing the site"""
-type CoreLegacyWidget implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreLegacyWidget implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -6885,7 +6888,7 @@ type CoreLegacyWidgetAttributes {
 }
 
 """A block used for editing the site"""
-type CoreList implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreList implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -7015,7 +7018,7 @@ type CoreListAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreListItem implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreListItem implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -7120,7 +7123,7 @@ type CoreListItemAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreLoginout implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreLoginout implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -7214,7 +7217,7 @@ type CoreLoginoutAttributes {
 }
 
 """A block used for editing the site"""
-type CoreMath implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreMath implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -7278,7 +7281,7 @@ type CoreMathAttributes {
 }
 
 """A block used for editing the site"""
-type CoreMediaText implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreMediaText implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -7468,7 +7471,7 @@ type CoreMediaTextAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreMissing implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreMissing implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -7532,7 +7535,7 @@ type CoreMissingAttributes {
 }
 
 """A block used for editing the site"""
-type CoreMore implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreMore implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -7591,7 +7594,7 @@ type CoreMoreAttributes {
 }
 
 """A block used for editing the site"""
-type CoreNavigation implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreNavigation implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -7765,7 +7768,7 @@ type CoreNavigationAttributes {
 }
 
 """A block used for editing the site"""
-type CoreNavigationLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreNavigationLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -7884,7 +7887,7 @@ type CoreNavigationLinkAttributes {
 }
 
 """A block used for editing the site"""
-type CoreNavigationSubmenu implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreNavigationSubmenu implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -8003,7 +8006,7 @@ type CoreNavigationSubmenuAttributes {
 }
 
 """A block used for editing the site"""
-type CoreNextpage implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreNextpage implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -8052,7 +8055,7 @@ type CoreNextpageAttributes {
 }
 
 """A block used for editing the site"""
-type CorePageList implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePageList implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -8151,7 +8154,7 @@ type CorePageListAttributes {
 }
 
 """A block used for editing the site"""
-type CorePageListItem implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePageListItem implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -8230,7 +8233,7 @@ type CorePageListItemAttributes {
 }
 
 """A block used for editing the site"""
-type CoreParagraph implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreParagraph implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -8355,7 +8358,7 @@ type CoreParagraphAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CorePattern implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePattern implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -8414,7 +8417,7 @@ type CorePatternAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostAuthor implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostAuthor implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -8538,7 +8541,7 @@ type CorePostAuthorAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostAuthorBiography implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostAuthorBiography implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -8632,7 +8635,7 @@ type CorePostAuthorBiographyAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostAuthorName implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostAuthorName implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -8736,7 +8739,7 @@ type CorePostAuthorNameAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostComments implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostComments implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -8825,7 +8828,7 @@ type CorePostCommentsAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostCommentsCount implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostCommentsCount implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -8919,7 +8922,7 @@ type CorePostCommentsCountAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostCommentsForm implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostCommentsForm implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -9008,7 +9011,7 @@ type CorePostCommentsFormAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostCommentsLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostCommentsLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -9092,7 +9095,7 @@ type CorePostCommentsLinkAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostContent implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostContent implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -9196,7 +9199,7 @@ type CorePostContentAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostDate implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostDate implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -9305,7 +9308,7 @@ type CorePostDateAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostExcerpt implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostExcerpt implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -9414,7 +9417,7 @@ type CorePostExcerptAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostFeaturedImage implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostFeaturedImage implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -9553,7 +9556,7 @@ type CorePostFeaturedImageAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostNavigationLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostNavigationLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -9667,7 +9670,7 @@ type CorePostNavigationLinkAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostTemplate implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostTemplate implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -9766,7 +9769,7 @@ type CorePostTemplateAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostTerms implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostTerms implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -9960,7 +9963,7 @@ type CorePostTermsToTermNodeConnectionPageInfo implements PageInfo & TermNodeCon
 }
 
 """A block used for editing the site"""
-type CorePostTimeToRead implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostTimeToRead implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -10069,7 +10072,7 @@ type CorePostTimeToReadAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostTitle implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostTitle implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -10193,7 +10196,7 @@ type CorePostTitleAttributes {
 }
 
 """A block used for editing the site"""
-type CorePreformatted implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePreformatted implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -10293,7 +10296,7 @@ type CorePreformattedAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CorePullquote implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePullquote implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -10408,7 +10411,7 @@ type CorePullquoteAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreQuery implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreQuery implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -10497,7 +10500,7 @@ type CoreQueryAttributes {
 }
 
 """A block used for editing the site"""
-type CoreQueryNoResults implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreQueryNoResults implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -10586,7 +10589,7 @@ type CoreQueryNoResultsAttributes {
 }
 
 """A block used for editing the site"""
-type CoreQueryPagination implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreQueryPagination implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -10690,7 +10693,7 @@ type CoreQueryPaginationAttributes {
 }
 
 """A block used for editing the site"""
-type CoreQueryPaginationNext implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreQueryPaginationNext implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -10774,7 +10777,7 @@ type CoreQueryPaginationNextAttributes {
 }
 
 """A block used for editing the site"""
-type CoreQueryPaginationNumbers implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreQueryPaginationNumbers implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -10858,7 +10861,7 @@ type CoreQueryPaginationNumbersAttributes {
 }
 
 """A block used for editing the site"""
-type CoreQueryPaginationPrevious implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreQueryPaginationPrevious implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -10942,7 +10945,7 @@ type CoreQueryPaginationPreviousAttributes {
 }
 
 """A block used for editing the site"""
-type CoreQueryTitle implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreQueryTitle implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -11066,7 +11069,7 @@ type CoreQueryTitleAttributes {
 }
 
 """A block used for editing the site"""
-type CoreQueryTotal implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreQueryTotal implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -11165,7 +11168,7 @@ type CoreQueryTotalAttributes {
 }
 
 """A block used for editing the site"""
-type CoreQuote implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreQuote implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -11290,7 +11293,7 @@ type CoreQuoteAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreReadMore implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreReadMore implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -11389,7 +11392,7 @@ type CoreReadMoreAttributes {
 }
 
 """A block used for editing the site"""
-type CoreRss implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreRss implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -11523,7 +11526,7 @@ type CoreRssAttributes {
 }
 
 """A block used for editing the site"""
-type CoreSearch implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreSearch implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -11667,7 +11670,7 @@ type CoreSearchAttributes {
 }
 
 """A block used for editing the site"""
-type CoreSeparator implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreSeparator implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -11762,7 +11765,7 @@ type CoreSeparatorAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreShortcode implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreShortcode implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -11816,7 +11819,7 @@ type CoreShortcodeAttributes {
 }
 
 """A block used for editing the site"""
-type CoreSiteLogo implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreSiteLogo implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -11900,7 +11903,7 @@ type CoreSiteLogoAttributes {
 }
 
 """A block used for editing the site"""
-type CoreSiteTagline implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreSiteTagline implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -12009,7 +12012,7 @@ type CoreSiteTaglineAttributes {
 }
 
 """A block used for editing the site"""
-type CoreSiteTitle implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreSiteTitle implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -12128,7 +12131,7 @@ type CoreSiteTitleAttributes {
 }
 
 """A block used for editing the site"""
-type CoreSocialLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreSocialLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -12202,7 +12205,7 @@ type CoreSocialLinkAttributes {
 }
 
 """A block used for editing the site"""
-type CoreSocialLinks implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreSocialLinks implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -12337,7 +12340,7 @@ type CoreSocialLinksAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreSpacer implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreSpacer implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -12412,7 +12415,7 @@ type CoreSpacerAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreTable implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreTable implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -12672,7 +12675,7 @@ type CoreTableAttributesHeadCells {
 }
 
 """A block used for editing the site"""
-type CoreTagCloud implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreTagCloud implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -12771,7 +12774,7 @@ type CoreTagCloudAttributes {
 }
 
 """A block used for editing the site"""
-type CoreTemplatePart implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreTemplatePart implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -12850,7 +12853,7 @@ type CoreTemplatePartAttributes {
 }
 
 """A block used for editing the site"""
-type CoreTermCount implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreTermCount implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -12944,7 +12947,7 @@ type CoreTermCountAttributes {
 }
 
 """A block used for editing the site"""
-type CoreTermDescription implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreTermDescription implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -13038,7 +13041,7 @@ type CoreTermDescriptionAttributes {
 }
 
 """A block used for editing the site"""
-type CoreTermName implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreTermName implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -13147,7 +13150,7 @@ type CoreTermNameAttributes {
 }
 
 """A block used for editing the site"""
-type CoreTermTemplate implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreTermTemplate implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -13246,7 +13249,7 @@ type CoreTermTemplateAttributes {
 }
 
 """A block used for editing the site"""
-type CoreTermsQuery implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreTermsQuery implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -13320,7 +13323,7 @@ type CoreTermsQueryAttributes {
 }
 
 """A block used for editing the site"""
-type CoreTextColumns implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreTextColumns implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -13399,7 +13402,7 @@ type CoreTextColumnsAttributesContent {
 }
 
 """A block used for editing the site"""
-type CoreVerse implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreVerse implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -13504,7 +13507,7 @@ type CoreVerseAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreVideo implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreVideo implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -13634,7 +13637,7 @@ type CoreVideoAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreWidgetGroup implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreWidgetGroup implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -14099,6 +14102,53 @@ type CreatePostPayload {
   post: Post
 }
 
+"""Input for the createSponsor mutation."""
+input CreateSponsorInput {
+  """
+  This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions.
+  """
+  clientMutationId: String
+
+  """The content of the object"""
+  content: String
+
+  """
+  The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17 
+  """
+  date: String
+
+  """The excerpt of the object"""
+  excerpt: String
+
+  """
+  A field used for ordering posts. This is typically used with nav menu items or for special ordering of hierarchical content types.
+  """
+  menuOrder: Int
+
+  """The password used to protect the content of the object"""
+  password: String
+
+  """The slug of the object"""
+  slug: String
+
+  """The status of the object"""
+  status: PostStatusEnum
+
+  """The title of the object"""
+  title: String
+}
+
+"""The payload for the createSponsor mutation."""
+type CreateSponsorPayload {
+  """
+  If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
+  """
+  clientMutationId: String
+
+  """The Post object mutation type."""
+  sponsor: Sponsor
+}
+
 """Input for the createTag mutation."""
 input CreateTagInput {
   """The slug that the post_tag will be an alias of"""
@@ -14508,6 +14558,39 @@ type DeletePostPayload {
 
   """The object before it was deleted"""
   post: Post
+}
+
+"""Input for the deleteSponsor mutation."""
+input DeleteSponsorInput {
+  """
+  This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions.
+  """
+  clientMutationId: String
+
+  """
+  Whether the object should be force deleted instead of being moved to the trash
+  """
+  forceDelete: Boolean
+
+  """The ID of the Sponsor to delete"""
+  id: ID!
+
+  """Override the edit lock when another user is editing the post"""
+  ignoreEditLock: Boolean
+}
+
+"""The payload for the deleteSponsor mutation."""
+type DeleteSponsorPayload {
+  """
+  If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
+  """
+  clientMutationId: String
+
+  """The ID of the deleted object"""
+  deletedId: ID
+
+  """The object before it was deleted"""
+  sponsor: Sponsor
 }
 
 """Input for the deleteTag mutation."""
@@ -18428,7 +18511,7 @@ enum MenuItemNodeIdTypeEnum {
 }
 
 """Deprecated in favor of MenuItemLinkable Interface"""
-union MenuItemObjectUnion = Category | Event | EventCategory | Page | Post | PostFormat | Tag
+union MenuItemObjectUnion = Category | Event | EventCategory | Page | Post | PostFormat | Sponsor | Tag
 
 """Connection between the MenuItem type and the Menu type"""
 type MenuItemToMenuConnectionEdge implements Edge & MenuConnectionEdge & OneToOneConnection {
@@ -19085,6 +19168,15 @@ type NodeWithRevisionsToContentNodeConnectionEdge implements ContentNodeConnecti
 
   """The node of the connection, without the edges"""
   node: ContentNode!
+}
+
+"""Node that has Sponsor content blocks associated with it"""
+interface NodeWithSponsorEditorBlocks implements NodeWithEditorBlocks {
+  """List of Sponsor editor blocks"""
+  editorBlocks(
+    """Returns the list of blocks as a flat list if true"""
+    flat: Boolean
+  ): [SponsorEditorBlock]
 }
 
 """
@@ -22576,6 +22668,12 @@ type RootMutation {
     input: CreatePostFormatInput!
   ): CreatePostFormatPayload
 
+  """The createSponsor mutation"""
+  createSponsor(
+    """Input for the createSponsor mutation"""
+    input: CreateSponsorInput!
+  ): CreateSponsorPayload
+
   """The createTag mutation"""
   createTag(
     """Input for the createTag mutation"""
@@ -22635,6 +22733,12 @@ type RootMutation {
     """Input for the deletePostFormat mutation"""
     input: DeletePostFormatInput!
   ): DeletePostFormatPayload
+
+  """The deleteSponsor mutation"""
+  deleteSponsor(
+    """Input for the deleteSponsor mutation"""
+    input: DeleteSponsorInput!
+  ): DeleteSponsorPayload
 
   """The deleteTag mutation"""
   deleteTag(
@@ -22769,6 +22873,12 @@ type RootMutation {
     """Input for the updateSettings mutation"""
     input: UpdateSettingsInput!
   ): UpdateSettingsPayload
+
+  """The updateSponsor mutation"""
+  updateSponsor(
+    """Input for the updateSponsor mutation"""
+    input: UpdateSponsorInput!
+  ): UpdateSponsorPayload
 
   """The updateTag mutation"""
   updateTag(
@@ -23382,6 +23492,59 @@ type RootQuery {
 
   """Returns seo site data"""
   seo: SEOConfig
+
+  """An object of the Sponsor Type. """
+  sponsor(
+    """
+    Whether to return the Preview Node instead of the Published Node. When the ID of a Node is provided along with asPreview being set to true, the preview node with un-published changes will be returned instead of the published node. If no preview node exists or the requester doesn't have proper capabilities to preview, no node will be returned. If the ID provided is a URI and has a preview query arg, it will be used as a fallback if the "asPreview" argument is not explicitly provided as an argument.
+    """
+    asPreview: Boolean
+
+    """The globally unique identifier of the object."""
+    id: ID!
+
+    """Type of unique identifier to fetch by. Default is Global ID"""
+    idType: SponsorIdType
+  ): Sponsor
+
+  """A Sponsor object"""
+  sponsorBy(
+    """Get the Sponsor object by its global ID"""
+    id: ID
+
+    """
+    Get the Sponsor by its slug (only available for non-hierarchical types)
+    """
+    slug: String
+
+    """Get the Sponsor by its database ID"""
+    sponsorId: Int
+
+    """Get the Sponsor by its uri"""
+    uri: String
+  ): Sponsor @deprecated(reason: "Deprecated in favor of using the single entry point for this type with ID and IDType fields. For example, instead of postBy( id: &quot;&quot; ), use post(id: &quot;&quot; idType: &quot;&quot;)")
+
+  """Connection between the RootQuery type and the Sponsor type"""
+  sponsors(
+    """
+    Cursor used along with the "first" argument to reference where in the dataset to get data
+    """
+    after: String
+
+    """
+    Cursor used along with the "last" argument to reference where in the dataset to get data
+    """
+    before: String
+
+    """The number of items to return after the referenced "after" cursor"""
+    first: Int
+
+    """The number of items to return before the referenced "before" cursor"""
+    last: Int
+
+    """Arguments for filtering the connection"""
+    where: RootQueryToSponsorConnectionWhereArgs
+  ): RootQueryToSponsorConnection
 
   """A 0bject"""
   tag(
@@ -25059,6 +25222,105 @@ input RootQueryToRevisionsConnectionWhereArgs {
   title: String
 }
 
+"""Connection between the RootQuery type and the Sponsor type"""
+type RootQueryToSponsorConnection implements Connection & SponsorConnection {
+  """Edges for the RootQueryToSponsorConnection connection"""
+  edges: [RootQueryToSponsorConnectionEdge!]!
+
+  """The nodes of the connection, without the edges"""
+  nodes: [Sponsor!]!
+
+  """Information about pagination in a connection."""
+  pageInfo: RootQueryToSponsorConnectionPageInfo!
+}
+
+"""An edge in a connection"""
+type RootQueryToSponsorConnectionEdge implements Edge & SponsorConnectionEdge {
+  """A cursor for use in pagination"""
+  cursor: String
+
+  """The item at the end of the edge"""
+  node: Sponsor!
+}
+
+"""
+Pagination metadata specific to &quot;RootQueryToSponsorConnection&quot; collections. Provides cursors and flags for navigating through sets of RootQueryToSponsorConnection Nodes.
+"""
+type RootQueryToSponsorConnectionPageInfo implements PageInfo & SponsorConnectionPageInfo & WPPageInfo {
+  """When paginating forwards, the cursor to continue."""
+  endCursor: String
+
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+
+  """Raw schema for page"""
+  seo: SEOPostTypePageInfo
+
+  """When paginating backwards, the cursor to continue."""
+  startCursor: String
+}
+
+"""Arguments for filtering the RootQueryToSponsorConnection connection"""
+input RootQueryToSponsorConnectionWhereArgs {
+  """Filter the connection based on dates"""
+  dateQuery: DateQueryInput
+
+  """
+  True for objects with passwords; False for objects without passwords; null for all objects with or without passwords
+  """
+  hasPassword: Boolean
+
+  """Specific database ID of the object"""
+  id: Int
+
+  """Array of IDs for the objects to retrieve"""
+  in: [ID]
+
+  """Get objects with a specific mimeType property"""
+  mimeType: MimeTypeEnum
+
+  """Slug / post_name of the object"""
+  name: String
+
+  """Specify objects to retrieve. Use slugs"""
+  nameIn: [String]
+
+  """
+  Specify IDs NOT to retrieve. If this is used in the same query as "in", it will be ignored
+  """
+  notIn: [ID]
+
+  """What parameter to use to order the objects by."""
+  orderby: [PostObjectsConnectionOrderbyInput]
+
+  """Use ID to return only children. Use 0 to return only top-level items"""
+  parent: ID
+
+  """Specify objects whose parent is in an array"""
+  parentIn: [ID]
+
+  """Specify posts whose parent is not in an array"""
+  parentNotIn: [ID]
+
+  """Show posts with a specific password."""
+  password: String
+
+  """Show Posts based on a keyword search"""
+  search: String
+
+  """Retrieve posts where post status is in an array."""
+  stati: [PostStatusEnum]
+
+  """Show posts with a specific status."""
+  status: PostStatusEnum
+
+  """Title of the object"""
+  title: String
+}
+
 """Connection between the RootQuery type and the tag type"""
 type RootQueryToTagConnection implements Connection & TagConnection {
   """Edges for the RootQueryToTagConnection connection"""
@@ -25679,6 +25941,9 @@ type SEOContentTypes {
 
   """"""
   post: SEOContentType
+
+  """"""
+  sponsor: SEOContentType
 }
 
 """The Yoast SEO meta data"""
@@ -26165,6 +26430,515 @@ type SiteTokenClientOptions implements LoginClientOptions {
 type SiteTokenLoginOptions implements LoginOptions {
   """Whether to set a WordPress authentication cookie on successful login."""
   useAuthenticationCookie: Boolean
+}
+
+"""The Sponsor type"""
+type Sponsor implements ContentNode & DatabaseIdentifier & MenuItemLinkable & Node & NodeWithContentEditor & NodeWithEditorBlocks & NodeWithExcerpt & NodeWithFeaturedImage & NodeWithRevisions & NodeWithSponsorEditorBlocks & NodeWithTemplate & NodeWithTitle & Previewable & UniformResourceIdentifiable {
+  """The ancestors of the content node."""
+  ancestors(
+    """
+    Cursor used along with the "first" argument to reference where in the dataset to get data
+    """
+    after: String
+
+    """
+    Cursor used along with the "last" argument to reference where in the dataset to get data
+    """
+    before: String
+
+    """The number of items to return after the referenced "after" cursor"""
+    first: Int
+
+    """The number of items to return before the referenced "before" cursor"""
+    last: Int
+  ): SponsorToSponsorConnection @deprecated(reason: "This content type is not hierarchical and typically will not have ancestors")
+
+  """"""
+  conditionalTags: ConditionalTags @deprecated(reason: "Deprecated in favor of using Next.js pages")
+
+  """The content of the post."""
+  content(
+    """Format of the field output"""
+    format: PostObjectFieldFormatEnum
+  ): String
+
+  """Connection between the ContentNode type and the ContentType type"""
+  contentType: ContentNodeToContentTypeConnectionEdge
+
+  """The name of the Content Type the node belongs to"""
+  contentTypeName: String!
+
+  """The unique identifier stored in the database"""
+  databaseId: Int!
+
+  """Post publishing date."""
+  date: String
+
+  """The publishing date set in GMT."""
+  dateGmt: String
+
+  """The desired slug of the post"""
+  desiredSlug: String
+
+  """
+  If a user has edited the node within the past 15 seconds, this will return the user that last edited. Null if the edit lock doesn&#039;t exist or is greater than 15 seconds
+  """
+  editingLockedBy: ContentNodeToEditLockConnectionEdge
+
+  """List of Sponsor editor blocks"""
+  editorBlocks(
+    """Returns the list of blocks as a flat list if true"""
+    flat: Boolean
+  ): [SponsorEditorBlock]
+
+  """The RSS enclosure for the object"""
+  enclosure: String
+
+  """Connection between the ContentNode type and the EnqueuedScript type"""
+  enqueuedScripts(
+    """
+    Cursor used along with the "first" argument to reference where in the dataset to get data
+    """
+    after: String
+
+    """
+    Cursor used along with the "last" argument to reference where in the dataset to get data
+    """
+    before: String
+
+    """The number of items to return after the referenced "after" cursor"""
+    first: Int
+
+    """The number of items to return before the referenced "before" cursor"""
+    last: Int
+  ): ContentNodeToEnqueuedScriptConnection
+
+  """
+  Connection between the ContentNode type and the EnqueuedStylesheet type
+  """
+  enqueuedStylesheets(
+    """
+    Cursor used along with the "first" argument to reference where in the dataset to get data
+    """
+    after: String
+
+    """
+    Cursor used along with the "last" argument to reference where in the dataset to get data
+    """
+    before: String
+
+    """The number of items to return after the referenced "after" cursor"""
+    first: Int
+
+    """The number of items to return before the referenced "before" cursor"""
+    last: Int
+  ): ContentNodeToEnqueuedStylesheetConnection
+
+  """The excerpt of the post."""
+  excerpt(
+    """Format of the field output"""
+    format: PostObjectFieldFormatEnum
+  ): String
+
+  """
+  Connection between the NodeWithFeaturedImage type and the MediaItem type
+  """
+  featuredImage: NodeWithFeaturedImageToMediaItemConnectionEdge
+
+  """
+  The database identifier for the featured image node assigned to the content node
+  """
+  featuredImageDatabaseId: Int
+
+  """Globally unique ID of the featured image assigned to the node"""
+  featuredImageId: ID
+
+  """
+  The global unique identifier for this post. This currently matches the value stored in WP_Post-&gt;guid and the guid column in the &quot;post_objects&quot; database table.
+  """
+  guid: String
+
+  """Whether the sponsor object is password protected."""
+  hasPassword: Boolean
+
+  """The globally unique identifier of the sponsor object."""
+  id: ID!
+
+  """Whether the node is a Comment"""
+  isComment: Boolean!
+
+  """Whether the node is a Content Node"""
+  isContentNode: Boolean!
+
+  """Whether the node represents the front page."""
+  isFrontPage: Boolean!
+
+  """Whether  the node represents the blog page."""
+  isPostsPage: Boolean!
+
+  """Whether the object is a node in the preview state"""
+  isPreview: Boolean
+
+  """Whether the object is restricted from the current viewer"""
+  isRestricted: Boolean
+
+  """True if the node is a revision of another node"""
+  isRevision: Boolean
+
+  """Whether the node is a Term"""
+  isTermNode: Boolean!
+
+  """The user that most recently edited the node"""
+  lastEditedBy: ContentNodeToEditLastConnectionEdge
+
+  """The permalink of the post"""
+  link: String
+
+  """
+  The local modified time for a post. If a post was recently updated the modified field will change to match the corresponding time.
+  """
+  modified: String
+
+  """
+  The GMT modified time for a post. If a post was recently updated the modified field will change to match the corresponding time in GMT.
+  """
+  modifiedGmt: String
+
+  """The parent of the content node."""
+  parent: SponsorToParentConnectionEdge @deprecated(reason: "This content type is not hierarchical and typically will not have a parent")
+
+  """The password for the sponsor object."""
+  password: String
+
+  """Connection between the Sponsor type and the Sponsor type"""
+  preview: SponsorToPreviewConnectionEdge
+
+  """The database id of the preview node"""
+  previewRevisionDatabaseId: Int
+
+  """Whether the object is a node in the preview state"""
+  previewRevisionId: ID
+
+  """
+  If the current node is a revision, this field exposes the node this is a revision of. Returns null if the node is not a revision of another node.
+  """
+  revisionOf: NodeWithRevisionsToContentNodeConnectionEdge
+
+  """Connection between the Sponsor type and the Sponsor type"""
+  revisions(
+    """
+    Cursor used along with the "first" argument to reference where in the dataset to get data
+    """
+    after: String
+
+    """
+    Cursor used along with the "last" argument to reference where in the dataset to get data
+    """
+    before: String
+
+    """The number of items to return after the referenced "after" cursor"""
+    first: Int
+
+    """The number of items to return before the referenced "before" cursor"""
+    last: Int
+
+    """Arguments for filtering the connection"""
+    where: SponsorToRevisionConnectionWhereArgs
+  ): SponsorToRevisionConnection
+
+  """The Yoast SEO data of the ContentNode"""
+  seo: PostTypeSEO
+
+  """
+  The uri slug for the post. This is equivalent to the WP_Post-&gt;post_name field and the post_name column in the database for the &quot;post_objects&quot; table.
+  """
+  slug: String
+
+  """The id field matches the WP_Post-&gt;ID field."""
+  sponsorId: Int! @deprecated(reason: "Deprecated in favor of the databaseId field")
+
+  """The current status of the object"""
+  status: String
+
+  """The template assigned to the node"""
+  template: ContentTemplate
+
+  """"""
+  templates: [String]
+
+  """
+  The title of the post. This is currently just the raw title. An amendment to support rendered title needs to be made.
+  """
+  title(
+    """Format of the field output"""
+    format: PostObjectFieldFormatEnum
+  ): String
+
+  """The unique resource identifier path"""
+  uri: String
+}
+
+"""
+A paginated collection of Sponsor Nodes, Supports cursor-based pagination and filtering to efficiently retrieve sets of Sponsor Nodes
+"""
+interface SponsorConnection implements Connection {
+  """
+  A list of edges (relational context) between RootQuery and connected Sponsor Nodes
+  """
+  edges: [SponsorConnectionEdge!]!
+
+  """A list of connected Sponsor Nodes"""
+  nodes: [Sponsor!]!
+
+  """Information about pagination in a connection."""
+  pageInfo: SponsorConnectionPageInfo!
+}
+
+"""
+Represents a connection to a Sponsor. Contains both the Sponsor Node and metadata about the relationship.
+"""
+interface SponsorConnectionEdge implements Edge {
+  """
+  Opaque reference to the nodes position in the connection. Value can be used with pagination args.
+  """
+  cursor: String
+
+  """The connected Sponsor Node"""
+  node: Sponsor!
+}
+
+"""
+Pagination metadata specific to &quot;SponsorConnectionEdge&quot; collections. Provides cursors and flags for navigating through sets of &quot;SponsorConnectionEdge&quot; Nodes.
+"""
+interface SponsorConnectionPageInfo implements PageInfo & WPPageInfo {
+  """When paginating forwards, the cursor to continue."""
+  endCursor: String
+
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+
+  """Raw schema for page"""
+  seo: SEOPostTypePageInfo
+
+  """When paginating backwards, the cursor to continue."""
+  startCursor: String
+}
+
+"""EditorBlock Interface for Sponsor Block Type"""
+interface SponsorEditorBlock implements EditorBlock {
+  """The API version of the Gutenberg Block"""
+  apiVersion: Int
+
+  """The name of the category the Block belongs to"""
+  blockEditorCategoryName: String
+
+  """The id of the Block"""
+  clientId: String
+
+  """CSS Classnames to apply to the block"""
+  cssClassNames: [String]
+
+  """The inner blocks of the Block"""
+  innerBlocks: [EditorBlock]
+
+  """Whether the block is Dynamic (server rendered)"""
+  isDynamic: Boolean!
+
+  """The name of the Block"""
+  name: String
+
+  """The parent id of the Block"""
+  parentClientId: String
+
+  """The rendered HTML for the block"""
+  renderedHtml: String
+
+  """The (GraphQL) type of the block"""
+  type: String
+}
+
+"""
+Identifier types for retrieving a specific Sponsor. Specifies which unique attribute is used to find an exact Sponsor.
+"""
+enum SponsorIdType {
+  """Identify a resource by the Database ID."""
+  DATABASE_ID
+
+  """Identify a resource by the (hashed) Global ID."""
+  ID
+
+  """
+  Identify a resource by the slug. Available to non-hierarchcial Types where the slug is a unique identifier.
+  """
+  SLUG
+
+  """Identify a resource by the URI."""
+  URI
+}
+
+"""Connection between the Sponsor type and the Sponsor type"""
+type SponsorToParentConnectionEdge implements Edge & OneToOneConnection & SponsorConnectionEdge {
+  """
+  Opaque reference to the nodes position in the connection. Value can be used with pagination args.
+  """
+  cursor: String
+
+  """The node of the connection, without the edges"""
+  node: Sponsor! @deprecated(reason: "This content type is not hierarchical and typically will not have a parent")
+}
+
+"""Connection between the Sponsor type and the Sponsor type"""
+type SponsorToPreviewConnectionEdge implements Edge & OneToOneConnection & SponsorConnectionEdge {
+  """
+  Opaque reference to the nodes position in the connection. Value can be used with pagination args.
+  """
+  cursor: String
+
+  """The node of the connection, without the edges"""
+  node: Sponsor!
+}
+
+"""Connection between the Sponsor type and the Sponsor type"""
+type SponsorToRevisionConnection implements Connection & SponsorConnection {
+  """Edges for the SponsorToRevisionConnection connection"""
+  edges: [SponsorToRevisionConnectionEdge!]!
+
+  """The nodes of the connection, without the edges"""
+  nodes: [Sponsor!]!
+
+  """Information about pagination in a connection."""
+  pageInfo: SponsorToRevisionConnectionPageInfo!
+}
+
+"""An edge in a connection"""
+type SponsorToRevisionConnectionEdge implements Edge & SponsorConnectionEdge {
+  """A cursor for use in pagination"""
+  cursor: String
+
+  """The item at the end of the edge"""
+  node: Sponsor!
+}
+
+"""
+Pagination metadata specific to &quot;SponsorToRevisionConnection&quot; collections. Provides cursors and flags for navigating through sets of SponsorToRevisionConnection Nodes.
+"""
+type SponsorToRevisionConnectionPageInfo implements PageInfo & SponsorConnectionPageInfo & WPPageInfo {
+  """When paginating forwards, the cursor to continue."""
+  endCursor: String
+
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+
+  """Raw schema for page"""
+  seo: SEOPostTypePageInfo
+
+  """When paginating backwards, the cursor to continue."""
+  startCursor: String
+}
+
+"""Arguments for filtering the SponsorToRevisionConnection connection"""
+input SponsorToRevisionConnectionWhereArgs {
+  """Filter the connection based on dates"""
+  dateQuery: DateQueryInput
+
+  """
+  True for objects with passwords; False for objects without passwords; null for all objects with or without passwords
+  """
+  hasPassword: Boolean
+
+  """Specific database ID of the object"""
+  id: Int
+
+  """Array of IDs for the objects to retrieve"""
+  in: [ID]
+
+  """Get objects with a specific mimeType property"""
+  mimeType: MimeTypeEnum
+
+  """Slug / post_name of the object"""
+  name: String
+
+  """Specify objects to retrieve. Use slugs"""
+  nameIn: [String]
+
+  """
+  Specify IDs NOT to retrieve. If this is used in the same query as "in", it will be ignored
+  """
+  notIn: [ID]
+
+  """What parameter to use to order the objects by."""
+  orderby: [PostObjectsConnectionOrderbyInput]
+
+  """Use ID to return only children. Use 0 to return only top-level items"""
+  parent: ID
+
+  """Specify objects whose parent is in an array"""
+  parentIn: [ID]
+
+  """Specify posts whose parent is not in an array"""
+  parentNotIn: [ID]
+
+  """Show posts with a specific password."""
+  password: String
+
+  """Show Posts based on a keyword search"""
+  search: String
+
+  """Retrieve posts where post status is in an array."""
+  stati: [PostStatusEnum]
+
+  """Show posts with a specific status."""
+  status: PostStatusEnum
+
+  """Title of the object"""
+  title: String
+}
+
+"""Connection between the Sponsor type and the Sponsor type"""
+type SponsorToSponsorConnection implements Connection & SponsorConnection {
+  """Edges for the SponsorToSponsorConnection connection"""
+  edges: [SponsorToSponsorConnectionEdge!]!
+
+  """The nodes of the connection, without the edges"""
+  nodes: [Sponsor!]!
+
+  """Information about pagination in a connection."""
+  pageInfo: SponsorToSponsorConnectionPageInfo!
+}
+
+"""An edge in a connection"""
+type SponsorToSponsorConnectionEdge implements Edge & SponsorConnectionEdge {
+  """A cursor for use in pagination"""
+  cursor: String @deprecated(reason: "This content type is not hierarchical and typically will not have ancestors")
+
+  """The item at the end of the edge"""
+  node: Sponsor! @deprecated(reason: "This content type is not hierarchical and typically will not have ancestors")
+}
+
+"""
+Pagination metadata specific to &quot;SponsorToSponsorConnection&quot; collections. Provides cursors and flags for navigating through sets of SponsorToSponsorConnection Nodes.
+"""
+type SponsorToSponsorConnectionPageInfo implements PageInfo & SponsorConnectionPageInfo & WPPageInfo {
+  """When paginating forwards, the cursor to continue."""
+  endCursor: String
+
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+
+  """Raw schema for page"""
+  seo: SEOPostTypePageInfo
+
+  """When paginating backwards, the cursor to continue."""
+  startCursor: String
 }
 
 """
@@ -27935,6 +28709,59 @@ type UpdateSettingsPayload {
   writingSettings: WritingSettings
 }
 
+"""Input for the updateSponsor mutation."""
+input UpdateSponsorInput {
+  """
+  This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions.
+  """
+  clientMutationId: String
+
+  """The content of the object"""
+  content: String
+
+  """
+  The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17 
+  """
+  date: String
+
+  """The excerpt of the object"""
+  excerpt: String
+
+  """The ID of the Sponsor object"""
+  id: ID!
+
+  """Override the edit lock when another user is editing the post"""
+  ignoreEditLock: Boolean
+
+  """
+  A field used for ordering posts. This is typically used with nav menu items or for special ordering of hierarchical content types.
+  """
+  menuOrder: Int
+
+  """The password used to protect the content of the object"""
+  password: String
+
+  """The slug of the object"""
+  slug: String
+
+  """The status of the object"""
+  status: PostStatusEnum
+
+  """The title of the object"""
+  title: String
+}
+
+"""The payload for the updateSponsor mutation."""
+type UpdateSponsorPayload {
+  """
+  If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
+  """
+  clientMutationId: String
+
+  """The Post object mutation type."""
+  sponsor: Sponsor
+}
+
 """Input for the updateTag mutation."""
 input UpdateTagInput {
   """The slug that the post_tag will be an alias of"""
@@ -29361,7 +30188,7 @@ type WritingSettings {
 }
 
 """A block used for editing the site"""
-type YoastFaqBlock implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type YoastFaqBlock implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -29425,7 +30252,7 @@ type YoastFaqBlockAttributes {
 }
 
 """A block used for editing the site"""
-type YoastHowToBlock implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type YoastHowToBlock implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -29534,7 +30361,7 @@ type YoastHowToBlockAttributes {
 }
 
 """A block used for editing the site"""
-type YoastSeoBreadcrumbs implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type YoastSeoBreadcrumbs implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 

--- a/playgrounds/full/wp-plugin/wpnuxt-demo/includes/class-cpt-sponsor.php
+++ b/playgrounds/full/wp-plugin/wpnuxt-demo/includes/class-cpt-sponsor.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace WPNuxt_Demo;
+
+/**
+ * Sponsor CPT — a deliberately minimal CPT for demonstrating the WPNuxt
+ * auto-generation feature. No ACF, no custom taxonomies, no custom where
+ * args — just the standard WordPress surfaces (title, editor, excerpt,
+ * thumbnail). Registering this on the backend is enough for WPNuxt to
+ * emit `useSponsors()`, `useSponsorByUri()` and `useSponsorBySlug()`
+ * composables with no hand-written GraphQL.
+ */
+class CPT_Sponsor
+{
+    public static function register(): void
+    {
+        register_post_type('sponsor', [
+            'labels' => [
+                'name'               => __('Sponsors', 'wpnuxt-demo'),
+                'singular_name'      => __('Sponsor', 'wpnuxt-demo'),
+                'add_new'            => __('Add New Sponsor', 'wpnuxt-demo'),
+                'add_new_item'       => __('Add New Sponsor', 'wpnuxt-demo'),
+                'edit_item'          => __('Edit Sponsor', 'wpnuxt-demo'),
+                'new_item'           => __('New Sponsor', 'wpnuxt-demo'),
+                'view_item'          => __('View Sponsor', 'wpnuxt-demo'),
+                'search_items'       => __('Search Sponsors', 'wpnuxt-demo'),
+                'not_found'          => __('No sponsors found', 'wpnuxt-demo'),
+                'not_found_in_trash' => __('No sponsors found in Trash', 'wpnuxt-demo'),
+                'all_items'          => __('All Sponsors', 'wpnuxt-demo'),
+                'menu_name'          => __('Sponsors', 'wpnuxt-demo'),
+            ],
+            'public'              => true,
+            'has_archive'         => true,
+            'rewrite'             => ['slug' => 'sponsors'],
+            'menu_icon'           => 'dashicons-awards',
+            'menu_position'       => 6,
+            'supports'            => ['title', 'editor', 'excerpt', 'thumbnail', 'revisions'],
+            'show_in_rest'        => true,
+            'show_in_graphql'     => true,
+            'graphql_single_name' => 'Sponsor',
+            'graphql_plural_name' => 'Sponsors',
+        ]);
+    }
+}

--- a/playgrounds/full/wp-plugin/wpnuxt-demo/wpnuxt-demo.php
+++ b/playgrounds/full/wp-plugin/wpnuxt-demo/wpnuxt-demo.php
@@ -17,6 +17,7 @@ if (! defined('ABSPATH')) {
 define('WPNUXT_DEMO_PATH', plugin_dir_path(__FILE__));
 
 require_once WPNUXT_DEMO_PATH . 'includes/class-cpt-event.php';
+require_once WPNUXT_DEMO_PATH . 'includes/class-cpt-sponsor.php';
 require_once WPNUXT_DEMO_PATH . 'includes/class-taxonomy-event-category.php';
 
 // Register nav menu locations
@@ -24,9 +25,10 @@ add_action('after_setup_theme', function () {
     register_nav_menus([ 'primary' => 'Primary Menu' ]);
 });
 
-// Initialize CPT and taxonomy
+// Initialize CPTs and taxonomy
 add_action('init', function () {
     WPNuxt_Demo\CPT_Event::register();
+    WPNuxt_Demo\CPT_Sponsor::register();
     WPNuxt_Demo\Taxonomy_Event_Category::register();
 });
 

--- a/playgrounds/ssg/schema.graphql
+++ b/playgrounds/ssg/schema.graphql
@@ -2116,6 +2116,9 @@ enum ContentTypeEnum {
 
   """The Type of Content object"""
   POST
+
+  """The Type of Content object"""
+  SPONSOR
 }
 
 """
@@ -2299,7 +2302,7 @@ enum ContentTypesOfTagEnum {
 }
 
 """A block used for editing the site"""
-type CoreAccordion implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreAccordion implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -2434,7 +2437,7 @@ type CoreAccordionAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreAccordionHeading implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreAccordionHeading implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -2554,7 +2557,7 @@ type CoreAccordionHeadingAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreAccordionItem implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreAccordionItem implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -2653,7 +2656,7 @@ type CoreAccordionItemAttributes {
 }
 
 """A block used for editing the site"""
-type CoreAccordionPanel implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreAccordionPanel implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -2757,7 +2760,7 @@ type CoreAccordionPanelAttributes {
 }
 
 """A block used for editing the site"""
-type CoreArchives implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreArchives implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -2871,7 +2874,7 @@ type CoreArchivesAttributes {
 }
 
 """A block used for editing the site"""
-type CoreAudio implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreAudio implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -2976,7 +2979,7 @@ type CoreAudioAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreAvatar implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreAvatar implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -3065,7 +3068,7 @@ type CoreAvatarAttributes {
 }
 
 """A block used for editing the site"""
-type CoreBlock implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreBlock implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -3124,7 +3127,7 @@ type CoreBlockAttributes {
 }
 
 """A block used for editing the site"""
-type CoreButton implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreButton implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -3279,7 +3282,7 @@ type CoreButtonAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreButtons implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreButtons implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -3384,7 +3387,7 @@ type CoreButtonsAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreCalendar implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCalendar implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -3478,7 +3481,7 @@ type CoreCalendarAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCategories implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCategories implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -3612,7 +3615,7 @@ type CoreCategoriesAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCode implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCode implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -3722,7 +3725,7 @@ type CoreCodeAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreColumn implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreColumn implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -3837,7 +3840,7 @@ type CoreColumnAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreColumns implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreColumns implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -3957,7 +3960,7 @@ type CoreColumnsAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreCommentAuthorName implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCommentAuthorName implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -4061,7 +4064,7 @@ type CoreCommentAuthorNameAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCommentContent implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCommentContent implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -4155,7 +4158,7 @@ type CoreCommentContentAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCommentDate implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCommentDate implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -4254,7 +4257,7 @@ type CoreCommentDateAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCommentEditLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCommentEditLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -4348,7 +4351,7 @@ type CoreCommentEditLinkAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCommentReplyLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCommentReplyLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -4437,7 +4440,7 @@ type CoreCommentReplyLinkAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCommentTemplate implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCommentTemplate implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -4516,7 +4519,7 @@ type CoreCommentTemplateAttributes {
 }
 
 """A block used for editing the site"""
-type CoreComments implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreComments implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -4620,7 +4623,7 @@ type CoreCommentsAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCommentsPagination implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCommentsPagination implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -4719,7 +4722,7 @@ type CoreCommentsPaginationAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCommentsPaginationNext implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCommentsPaginationNext implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -4803,7 +4806,7 @@ type CoreCommentsPaginationNextAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCommentsPaginationNumbers implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCommentsPaginationNumbers implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -4882,7 +4885,7 @@ type CoreCommentsPaginationNumbersAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCommentsPaginationPrevious implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCommentsPaginationPrevious implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -4966,7 +4969,7 @@ type CoreCommentsPaginationPreviousAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCommentsTitle implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCommentsTitle implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -5085,7 +5088,7 @@ type CoreCommentsTitleAttributes {
 }
 
 """A block used for editing the site"""
-type CoreCover implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreCover implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -5285,7 +5288,7 @@ type CoreCoverAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreDetails implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreDetails implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -5410,7 +5413,7 @@ type CoreDetailsAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreEmbed implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreEmbed implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -5509,7 +5512,7 @@ type CoreEmbedAttributes {
 }
 
 """A block used for editing the site"""
-type CoreFile implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreFile implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -5649,7 +5652,7 @@ type CoreFileAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreFootnotes implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreFootnotes implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -5733,7 +5736,7 @@ type CoreFootnotesAttributes {
 }
 
 """A block used for editing the site"""
-type CoreFreeform implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreFreeform implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -5787,7 +5790,7 @@ type CoreFreeformAttributes {
 }
 
 """A block used for editing the site"""
-type CoreGallery implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreGallery implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -5977,7 +5980,7 @@ type CoreGalleryAttributesImages {
 }
 
 """A block used for editing the site"""
-type CoreGroup implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreGroup implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -6097,7 +6100,7 @@ type CoreGroupAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreHeading implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreHeading implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -6227,7 +6230,7 @@ type CoreHeadingAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreHomeLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreHomeLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -6301,7 +6304,7 @@ type CoreHomeLinkAttributes {
 }
 
 """A block used for editing the site"""
-type CoreHtml implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreHtml implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -6355,7 +6358,7 @@ type CoreHtmlAttributes {
 }
 
 """A block used for editing the site"""
-type CoreImage implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreImage implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -6528,7 +6531,7 @@ type CoreImageAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreLatestComments implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreLatestComments implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -6637,7 +6640,7 @@ type CoreLatestCommentsAttributes {
 }
 
 """A block used for editing the site"""
-type CoreLatestPosts implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreLatestPosts implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -6821,7 +6824,7 @@ type CoreLatestPostsAttributes {
 }
 
 """A block used for editing the site"""
-type CoreLegacyWidget implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreLegacyWidget implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -6885,7 +6888,7 @@ type CoreLegacyWidgetAttributes {
 }
 
 """A block used for editing the site"""
-type CoreList implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreList implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -7015,7 +7018,7 @@ type CoreListAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreListItem implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreListItem implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -7120,7 +7123,7 @@ type CoreListItemAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreLoginout implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreLoginout implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -7214,7 +7217,7 @@ type CoreLoginoutAttributes {
 }
 
 """A block used for editing the site"""
-type CoreMath implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreMath implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -7278,7 +7281,7 @@ type CoreMathAttributes {
 }
 
 """A block used for editing the site"""
-type CoreMediaText implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreMediaText implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -7468,7 +7471,7 @@ type CoreMediaTextAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreMissing implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreMissing implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -7532,7 +7535,7 @@ type CoreMissingAttributes {
 }
 
 """A block used for editing the site"""
-type CoreMore implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreMore implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -7591,7 +7594,7 @@ type CoreMoreAttributes {
 }
 
 """A block used for editing the site"""
-type CoreNavigation implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreNavigation implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -7765,7 +7768,7 @@ type CoreNavigationAttributes {
 }
 
 """A block used for editing the site"""
-type CoreNavigationLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreNavigationLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -7884,7 +7887,7 @@ type CoreNavigationLinkAttributes {
 }
 
 """A block used for editing the site"""
-type CoreNavigationSubmenu implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreNavigationSubmenu implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -8003,7 +8006,7 @@ type CoreNavigationSubmenuAttributes {
 }
 
 """A block used for editing the site"""
-type CoreNextpage implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreNextpage implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -8052,7 +8055,7 @@ type CoreNextpageAttributes {
 }
 
 """A block used for editing the site"""
-type CorePageList implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePageList implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -8151,7 +8154,7 @@ type CorePageListAttributes {
 }
 
 """A block used for editing the site"""
-type CorePageListItem implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePageListItem implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -8230,7 +8233,7 @@ type CorePageListItemAttributes {
 }
 
 """A block used for editing the site"""
-type CoreParagraph implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreParagraph implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -8355,7 +8358,7 @@ type CoreParagraphAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CorePattern implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePattern implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -8414,7 +8417,7 @@ type CorePatternAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostAuthor implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostAuthor implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -8538,7 +8541,7 @@ type CorePostAuthorAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostAuthorBiography implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostAuthorBiography implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -8632,7 +8635,7 @@ type CorePostAuthorBiographyAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostAuthorName implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostAuthorName implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -8736,7 +8739,7 @@ type CorePostAuthorNameAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostComments implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostComments implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -8825,7 +8828,7 @@ type CorePostCommentsAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostCommentsCount implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostCommentsCount implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -8919,7 +8922,7 @@ type CorePostCommentsCountAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostCommentsForm implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostCommentsForm implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -9008,7 +9011,7 @@ type CorePostCommentsFormAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostCommentsLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostCommentsLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -9092,7 +9095,7 @@ type CorePostCommentsLinkAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostContent implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostContent implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -9196,7 +9199,7 @@ type CorePostContentAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostDate implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostDate implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -9305,7 +9308,7 @@ type CorePostDateAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostExcerpt implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostExcerpt implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -9414,7 +9417,7 @@ type CorePostExcerptAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostFeaturedImage implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostFeaturedImage implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -9553,7 +9556,7 @@ type CorePostFeaturedImageAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostNavigationLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostNavigationLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -9667,7 +9670,7 @@ type CorePostNavigationLinkAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostTemplate implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostTemplate implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -9766,7 +9769,7 @@ type CorePostTemplateAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostTerms implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostTerms implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -9960,7 +9963,7 @@ type CorePostTermsToTermNodeConnectionPageInfo implements PageInfo & TermNodeCon
 }
 
 """A block used for editing the site"""
-type CorePostTimeToRead implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostTimeToRead implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -10069,7 +10072,7 @@ type CorePostTimeToReadAttributes {
 }
 
 """A block used for editing the site"""
-type CorePostTitle implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePostTitle implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -10193,7 +10196,7 @@ type CorePostTitleAttributes {
 }
 
 """A block used for editing the site"""
-type CorePreformatted implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePreformatted implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -10293,7 +10296,7 @@ type CorePreformattedAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CorePullquote implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CorePullquote implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -10408,7 +10411,7 @@ type CorePullquoteAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreQuery implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreQuery implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -10497,7 +10500,7 @@ type CoreQueryAttributes {
 }
 
 """A block used for editing the site"""
-type CoreQueryNoResults implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreQueryNoResults implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -10586,7 +10589,7 @@ type CoreQueryNoResultsAttributes {
 }
 
 """A block used for editing the site"""
-type CoreQueryPagination implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreQueryPagination implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -10690,7 +10693,7 @@ type CoreQueryPaginationAttributes {
 }
 
 """A block used for editing the site"""
-type CoreQueryPaginationNext implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreQueryPaginationNext implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -10774,7 +10777,7 @@ type CoreQueryPaginationNextAttributes {
 }
 
 """A block used for editing the site"""
-type CoreQueryPaginationNumbers implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreQueryPaginationNumbers implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -10858,7 +10861,7 @@ type CoreQueryPaginationNumbersAttributes {
 }
 
 """A block used for editing the site"""
-type CoreQueryPaginationPrevious implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreQueryPaginationPrevious implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -10942,7 +10945,7 @@ type CoreQueryPaginationPreviousAttributes {
 }
 
 """A block used for editing the site"""
-type CoreQueryTitle implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreQueryTitle implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -11066,7 +11069,7 @@ type CoreQueryTitleAttributes {
 }
 
 """A block used for editing the site"""
-type CoreQueryTotal implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreQueryTotal implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -11165,7 +11168,7 @@ type CoreQueryTotalAttributes {
 }
 
 """A block used for editing the site"""
-type CoreQuote implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreQuote implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -11290,7 +11293,7 @@ type CoreQuoteAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreReadMore implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreReadMore implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -11389,7 +11392,7 @@ type CoreReadMoreAttributes {
 }
 
 """A block used for editing the site"""
-type CoreRss implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreRss implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -11523,7 +11526,7 @@ type CoreRssAttributes {
 }
 
 """A block used for editing the site"""
-type CoreSearch implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreSearch implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -11667,7 +11670,7 @@ type CoreSearchAttributes {
 }
 
 """A block used for editing the site"""
-type CoreSeparator implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreSeparator implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -11762,7 +11765,7 @@ type CoreSeparatorAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreShortcode implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreShortcode implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -11816,7 +11819,7 @@ type CoreShortcodeAttributes {
 }
 
 """A block used for editing the site"""
-type CoreSiteLogo implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreSiteLogo implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -11900,7 +11903,7 @@ type CoreSiteLogoAttributes {
 }
 
 """A block used for editing the site"""
-type CoreSiteTagline implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreSiteTagline implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -12009,7 +12012,7 @@ type CoreSiteTaglineAttributes {
 }
 
 """A block used for editing the site"""
-type CoreSiteTitle implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreSiteTitle implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -12128,7 +12131,7 @@ type CoreSiteTitleAttributes {
 }
 
 """A block used for editing the site"""
-type CoreSocialLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreSocialLink implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -12202,7 +12205,7 @@ type CoreSocialLinkAttributes {
 }
 
 """A block used for editing the site"""
-type CoreSocialLinks implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreSocialLinks implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -12337,7 +12340,7 @@ type CoreSocialLinksAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreSpacer implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreSpacer implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -12412,7 +12415,7 @@ type CoreSpacerAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreTable implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreTable implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -12672,7 +12675,7 @@ type CoreTableAttributesHeadCells {
 }
 
 """A block used for editing the site"""
-type CoreTagCloud implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreTagCloud implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -12771,7 +12774,7 @@ type CoreTagCloudAttributes {
 }
 
 """A block used for editing the site"""
-type CoreTemplatePart implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreTemplatePart implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -12850,7 +12853,7 @@ type CoreTemplatePartAttributes {
 }
 
 """A block used for editing the site"""
-type CoreTermCount implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreTermCount implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -12944,7 +12947,7 @@ type CoreTermCountAttributes {
 }
 
 """A block used for editing the site"""
-type CoreTermDescription implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreTermDescription implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -13038,7 +13041,7 @@ type CoreTermDescriptionAttributes {
 }
 
 """A block used for editing the site"""
-type CoreTermName implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreTermName implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -13147,7 +13150,7 @@ type CoreTermNameAttributes {
 }
 
 """A block used for editing the site"""
-type CoreTermTemplate implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreTermTemplate implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -13246,7 +13249,7 @@ type CoreTermTemplateAttributes {
 }
 
 """A block used for editing the site"""
-type CoreTermsQuery implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreTermsQuery implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -13320,7 +13323,7 @@ type CoreTermsQueryAttributes {
 }
 
 """A block used for editing the site"""
-type CoreTextColumns implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreTextColumns implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -13399,7 +13402,7 @@ type CoreTextColumnsAttributesContent {
 }
 
 """A block used for editing the site"""
-type CoreVerse implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreVerse implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -13504,7 +13507,7 @@ type CoreVerseAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreVideo implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreVideo implements BlockWithSupportsAnchor & EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The anchor field for the block."""
   anchor: String
 
@@ -13634,7 +13637,7 @@ type CoreVideoAttributes implements BlockWithSupportsAnchor {
 }
 
 """A block used for editing the site"""
-type CoreWidgetGroup implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type CoreWidgetGroup implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -14099,6 +14102,53 @@ type CreatePostPayload {
   post: Post
 }
 
+"""Input for the createSponsor mutation."""
+input CreateSponsorInput {
+  """
+  This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions.
+  """
+  clientMutationId: String
+
+  """The content of the object"""
+  content: String
+
+  """
+  The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17 
+  """
+  date: String
+
+  """The excerpt of the object"""
+  excerpt: String
+
+  """
+  A field used for ordering posts. This is typically used with nav menu items or for special ordering of hierarchical content types.
+  """
+  menuOrder: Int
+
+  """The password used to protect the content of the object"""
+  password: String
+
+  """The slug of the object"""
+  slug: String
+
+  """The status of the object"""
+  status: PostStatusEnum
+
+  """The title of the object"""
+  title: String
+}
+
+"""The payload for the createSponsor mutation."""
+type CreateSponsorPayload {
+  """
+  If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
+  """
+  clientMutationId: String
+
+  """The Post object mutation type."""
+  sponsor: Sponsor
+}
+
 """Input for the createTag mutation."""
 input CreateTagInput {
   """The slug that the post_tag will be an alias of"""
@@ -14508,6 +14558,39 @@ type DeletePostPayload {
 
   """The object before it was deleted"""
   post: Post
+}
+
+"""Input for the deleteSponsor mutation."""
+input DeleteSponsorInput {
+  """
+  This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions.
+  """
+  clientMutationId: String
+
+  """
+  Whether the object should be force deleted instead of being moved to the trash
+  """
+  forceDelete: Boolean
+
+  """The ID of the Sponsor to delete"""
+  id: ID!
+
+  """Override the edit lock when another user is editing the post"""
+  ignoreEditLock: Boolean
+}
+
+"""The payload for the deleteSponsor mutation."""
+type DeleteSponsorPayload {
+  """
+  If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
+  """
+  clientMutationId: String
+
+  """The ID of the deleted object"""
+  deletedId: ID
+
+  """The object before it was deleted"""
+  sponsor: Sponsor
 }
 
 """Input for the deleteTag mutation."""
@@ -18428,7 +18511,7 @@ enum MenuItemNodeIdTypeEnum {
 }
 
 """Deprecated in favor of MenuItemLinkable Interface"""
-union MenuItemObjectUnion = Category | Event | EventCategory | Page | Post | PostFormat | Tag
+union MenuItemObjectUnion = Category | Event | EventCategory | Page | Post | PostFormat | Sponsor | Tag
 
 """Connection between the MenuItem type and the Menu type"""
 type MenuItemToMenuConnectionEdge implements Edge & MenuConnectionEdge & OneToOneConnection {
@@ -19085,6 +19168,15 @@ type NodeWithRevisionsToContentNodeConnectionEdge implements ContentNodeConnecti
 
   """The node of the connection, without the edges"""
   node: ContentNode!
+}
+
+"""Node that has Sponsor content blocks associated with it"""
+interface NodeWithSponsorEditorBlocks implements NodeWithEditorBlocks {
+  """List of Sponsor editor blocks"""
+  editorBlocks(
+    """Returns the list of blocks as a flat list if true"""
+    flat: Boolean
+  ): [SponsorEditorBlock]
 }
 
 """
@@ -22576,6 +22668,12 @@ type RootMutation {
     input: CreatePostFormatInput!
   ): CreatePostFormatPayload
 
+  """The createSponsor mutation"""
+  createSponsor(
+    """Input for the createSponsor mutation"""
+    input: CreateSponsorInput!
+  ): CreateSponsorPayload
+
   """The createTag mutation"""
   createTag(
     """Input for the createTag mutation"""
@@ -22635,6 +22733,12 @@ type RootMutation {
     """Input for the deletePostFormat mutation"""
     input: DeletePostFormatInput!
   ): DeletePostFormatPayload
+
+  """The deleteSponsor mutation"""
+  deleteSponsor(
+    """Input for the deleteSponsor mutation"""
+    input: DeleteSponsorInput!
+  ): DeleteSponsorPayload
 
   """The deleteTag mutation"""
   deleteTag(
@@ -22769,6 +22873,12 @@ type RootMutation {
     """Input for the updateSettings mutation"""
     input: UpdateSettingsInput!
   ): UpdateSettingsPayload
+
+  """The updateSponsor mutation"""
+  updateSponsor(
+    """Input for the updateSponsor mutation"""
+    input: UpdateSponsorInput!
+  ): UpdateSponsorPayload
 
   """The updateTag mutation"""
   updateTag(
@@ -23382,6 +23492,59 @@ type RootQuery {
 
   """Returns seo site data"""
   seo: SEOConfig
+
+  """An object of the Sponsor Type. """
+  sponsor(
+    """
+    Whether to return the Preview Node instead of the Published Node. When the ID of a Node is provided along with asPreview being set to true, the preview node with un-published changes will be returned instead of the published node. If no preview node exists or the requester doesn't have proper capabilities to preview, no node will be returned. If the ID provided is a URI and has a preview query arg, it will be used as a fallback if the "asPreview" argument is not explicitly provided as an argument.
+    """
+    asPreview: Boolean
+
+    """The globally unique identifier of the object."""
+    id: ID!
+
+    """Type of unique identifier to fetch by. Default is Global ID"""
+    idType: SponsorIdType
+  ): Sponsor
+
+  """A Sponsor object"""
+  sponsorBy(
+    """Get the Sponsor object by its global ID"""
+    id: ID
+
+    """
+    Get the Sponsor by its slug (only available for non-hierarchical types)
+    """
+    slug: String
+
+    """Get the Sponsor by its database ID"""
+    sponsorId: Int
+
+    """Get the Sponsor by its uri"""
+    uri: String
+  ): Sponsor @deprecated(reason: "Deprecated in favor of using the single entry point for this type with ID and IDType fields. For example, instead of postBy( id: &quot;&quot; ), use post(id: &quot;&quot; idType: &quot;&quot;)")
+
+  """Connection between the RootQuery type and the Sponsor type"""
+  sponsors(
+    """
+    Cursor used along with the "first" argument to reference where in the dataset to get data
+    """
+    after: String
+
+    """
+    Cursor used along with the "last" argument to reference where in the dataset to get data
+    """
+    before: String
+
+    """The number of items to return after the referenced "after" cursor"""
+    first: Int
+
+    """The number of items to return before the referenced "before" cursor"""
+    last: Int
+
+    """Arguments for filtering the connection"""
+    where: RootQueryToSponsorConnectionWhereArgs
+  ): RootQueryToSponsorConnection
 
   """A 0bject"""
   tag(
@@ -25059,6 +25222,105 @@ input RootQueryToRevisionsConnectionWhereArgs {
   title: String
 }
 
+"""Connection between the RootQuery type and the Sponsor type"""
+type RootQueryToSponsorConnection implements Connection & SponsorConnection {
+  """Edges for the RootQueryToSponsorConnection connection"""
+  edges: [RootQueryToSponsorConnectionEdge!]!
+
+  """The nodes of the connection, without the edges"""
+  nodes: [Sponsor!]!
+
+  """Information about pagination in a connection."""
+  pageInfo: RootQueryToSponsorConnectionPageInfo!
+}
+
+"""An edge in a connection"""
+type RootQueryToSponsorConnectionEdge implements Edge & SponsorConnectionEdge {
+  """A cursor for use in pagination"""
+  cursor: String
+
+  """The item at the end of the edge"""
+  node: Sponsor!
+}
+
+"""
+Pagination metadata specific to &quot;RootQueryToSponsorConnection&quot; collections. Provides cursors and flags for navigating through sets of RootQueryToSponsorConnection Nodes.
+"""
+type RootQueryToSponsorConnectionPageInfo implements PageInfo & SponsorConnectionPageInfo & WPPageInfo {
+  """When paginating forwards, the cursor to continue."""
+  endCursor: String
+
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+
+  """Raw schema for page"""
+  seo: SEOPostTypePageInfo
+
+  """When paginating backwards, the cursor to continue."""
+  startCursor: String
+}
+
+"""Arguments for filtering the RootQueryToSponsorConnection connection"""
+input RootQueryToSponsorConnectionWhereArgs {
+  """Filter the connection based on dates"""
+  dateQuery: DateQueryInput
+
+  """
+  True for objects with passwords; False for objects without passwords; null for all objects with or without passwords
+  """
+  hasPassword: Boolean
+
+  """Specific database ID of the object"""
+  id: Int
+
+  """Array of IDs for the objects to retrieve"""
+  in: [ID]
+
+  """Get objects with a specific mimeType property"""
+  mimeType: MimeTypeEnum
+
+  """Slug / post_name of the object"""
+  name: String
+
+  """Specify objects to retrieve. Use slugs"""
+  nameIn: [String]
+
+  """
+  Specify IDs NOT to retrieve. If this is used in the same query as "in", it will be ignored
+  """
+  notIn: [ID]
+
+  """What parameter to use to order the objects by."""
+  orderby: [PostObjectsConnectionOrderbyInput]
+
+  """Use ID to return only children. Use 0 to return only top-level items"""
+  parent: ID
+
+  """Specify objects whose parent is in an array"""
+  parentIn: [ID]
+
+  """Specify posts whose parent is not in an array"""
+  parentNotIn: [ID]
+
+  """Show posts with a specific password."""
+  password: String
+
+  """Show Posts based on a keyword search"""
+  search: String
+
+  """Retrieve posts where post status is in an array."""
+  stati: [PostStatusEnum]
+
+  """Show posts with a specific status."""
+  status: PostStatusEnum
+
+  """Title of the object"""
+  title: String
+}
+
 """Connection between the RootQuery type and the tag type"""
 type RootQueryToTagConnection implements Connection & TagConnection {
   """Edges for the RootQueryToTagConnection connection"""
@@ -25679,6 +25941,9 @@ type SEOContentTypes {
 
   """"""
   post: SEOContentType
+
+  """"""
+  sponsor: SEOContentType
 }
 
 """The Yoast SEO meta data"""
@@ -26165,6 +26430,515 @@ type SiteTokenClientOptions implements LoginClientOptions {
 type SiteTokenLoginOptions implements LoginOptions {
   """Whether to set a WordPress authentication cookie on successful login."""
   useAuthenticationCookie: Boolean
+}
+
+"""The Sponsor type"""
+type Sponsor implements ContentNode & DatabaseIdentifier & MenuItemLinkable & Node & NodeWithContentEditor & NodeWithEditorBlocks & NodeWithExcerpt & NodeWithFeaturedImage & NodeWithRevisions & NodeWithSponsorEditorBlocks & NodeWithTemplate & NodeWithTitle & Previewable & UniformResourceIdentifiable {
+  """The ancestors of the content node."""
+  ancestors(
+    """
+    Cursor used along with the "first" argument to reference where in the dataset to get data
+    """
+    after: String
+
+    """
+    Cursor used along with the "last" argument to reference where in the dataset to get data
+    """
+    before: String
+
+    """The number of items to return after the referenced "after" cursor"""
+    first: Int
+
+    """The number of items to return before the referenced "before" cursor"""
+    last: Int
+  ): SponsorToSponsorConnection @deprecated(reason: "This content type is not hierarchical and typically will not have ancestors")
+
+  """"""
+  conditionalTags: ConditionalTags @deprecated(reason: "Deprecated in favor of using Next.js pages")
+
+  """The content of the post."""
+  content(
+    """Format of the field output"""
+    format: PostObjectFieldFormatEnum
+  ): String
+
+  """Connection between the ContentNode type and the ContentType type"""
+  contentType: ContentNodeToContentTypeConnectionEdge
+
+  """The name of the Content Type the node belongs to"""
+  contentTypeName: String!
+
+  """The unique identifier stored in the database"""
+  databaseId: Int!
+
+  """Post publishing date."""
+  date: String
+
+  """The publishing date set in GMT."""
+  dateGmt: String
+
+  """The desired slug of the post"""
+  desiredSlug: String
+
+  """
+  If a user has edited the node within the past 15 seconds, this will return the user that last edited. Null if the edit lock doesn&#039;t exist or is greater than 15 seconds
+  """
+  editingLockedBy: ContentNodeToEditLockConnectionEdge
+
+  """List of Sponsor editor blocks"""
+  editorBlocks(
+    """Returns the list of blocks as a flat list if true"""
+    flat: Boolean
+  ): [SponsorEditorBlock]
+
+  """The RSS enclosure for the object"""
+  enclosure: String
+
+  """Connection between the ContentNode type and the EnqueuedScript type"""
+  enqueuedScripts(
+    """
+    Cursor used along with the "first" argument to reference where in the dataset to get data
+    """
+    after: String
+
+    """
+    Cursor used along with the "last" argument to reference where in the dataset to get data
+    """
+    before: String
+
+    """The number of items to return after the referenced "after" cursor"""
+    first: Int
+
+    """The number of items to return before the referenced "before" cursor"""
+    last: Int
+  ): ContentNodeToEnqueuedScriptConnection
+
+  """
+  Connection between the ContentNode type and the EnqueuedStylesheet type
+  """
+  enqueuedStylesheets(
+    """
+    Cursor used along with the "first" argument to reference where in the dataset to get data
+    """
+    after: String
+
+    """
+    Cursor used along with the "last" argument to reference where in the dataset to get data
+    """
+    before: String
+
+    """The number of items to return after the referenced "after" cursor"""
+    first: Int
+
+    """The number of items to return before the referenced "before" cursor"""
+    last: Int
+  ): ContentNodeToEnqueuedStylesheetConnection
+
+  """The excerpt of the post."""
+  excerpt(
+    """Format of the field output"""
+    format: PostObjectFieldFormatEnum
+  ): String
+
+  """
+  Connection between the NodeWithFeaturedImage type and the MediaItem type
+  """
+  featuredImage: NodeWithFeaturedImageToMediaItemConnectionEdge
+
+  """
+  The database identifier for the featured image node assigned to the content node
+  """
+  featuredImageDatabaseId: Int
+
+  """Globally unique ID of the featured image assigned to the node"""
+  featuredImageId: ID
+
+  """
+  The global unique identifier for this post. This currently matches the value stored in WP_Post-&gt;guid and the guid column in the &quot;post_objects&quot; database table.
+  """
+  guid: String
+
+  """Whether the sponsor object is password protected."""
+  hasPassword: Boolean
+
+  """The globally unique identifier of the sponsor object."""
+  id: ID!
+
+  """Whether the node is a Comment"""
+  isComment: Boolean!
+
+  """Whether the node is a Content Node"""
+  isContentNode: Boolean!
+
+  """Whether the node represents the front page."""
+  isFrontPage: Boolean!
+
+  """Whether  the node represents the blog page."""
+  isPostsPage: Boolean!
+
+  """Whether the object is a node in the preview state"""
+  isPreview: Boolean
+
+  """Whether the object is restricted from the current viewer"""
+  isRestricted: Boolean
+
+  """True if the node is a revision of another node"""
+  isRevision: Boolean
+
+  """Whether the node is a Term"""
+  isTermNode: Boolean!
+
+  """The user that most recently edited the node"""
+  lastEditedBy: ContentNodeToEditLastConnectionEdge
+
+  """The permalink of the post"""
+  link: String
+
+  """
+  The local modified time for a post. If a post was recently updated the modified field will change to match the corresponding time.
+  """
+  modified: String
+
+  """
+  The GMT modified time for a post. If a post was recently updated the modified field will change to match the corresponding time in GMT.
+  """
+  modifiedGmt: String
+
+  """The parent of the content node."""
+  parent: SponsorToParentConnectionEdge @deprecated(reason: "This content type is not hierarchical and typically will not have a parent")
+
+  """The password for the sponsor object."""
+  password: String
+
+  """Connection between the Sponsor type and the Sponsor type"""
+  preview: SponsorToPreviewConnectionEdge
+
+  """The database id of the preview node"""
+  previewRevisionDatabaseId: Int
+
+  """Whether the object is a node in the preview state"""
+  previewRevisionId: ID
+
+  """
+  If the current node is a revision, this field exposes the node this is a revision of. Returns null if the node is not a revision of another node.
+  """
+  revisionOf: NodeWithRevisionsToContentNodeConnectionEdge
+
+  """Connection between the Sponsor type and the Sponsor type"""
+  revisions(
+    """
+    Cursor used along with the "first" argument to reference where in the dataset to get data
+    """
+    after: String
+
+    """
+    Cursor used along with the "last" argument to reference where in the dataset to get data
+    """
+    before: String
+
+    """The number of items to return after the referenced "after" cursor"""
+    first: Int
+
+    """The number of items to return before the referenced "before" cursor"""
+    last: Int
+
+    """Arguments for filtering the connection"""
+    where: SponsorToRevisionConnectionWhereArgs
+  ): SponsorToRevisionConnection
+
+  """The Yoast SEO data of the ContentNode"""
+  seo: PostTypeSEO
+
+  """
+  The uri slug for the post. This is equivalent to the WP_Post-&gt;post_name field and the post_name column in the database for the &quot;post_objects&quot; table.
+  """
+  slug: String
+
+  """The id field matches the WP_Post-&gt;ID field."""
+  sponsorId: Int! @deprecated(reason: "Deprecated in favor of the databaseId field")
+
+  """The current status of the object"""
+  status: String
+
+  """The template assigned to the node"""
+  template: ContentTemplate
+
+  """"""
+  templates: [String]
+
+  """
+  The title of the post. This is currently just the raw title. An amendment to support rendered title needs to be made.
+  """
+  title(
+    """Format of the field output"""
+    format: PostObjectFieldFormatEnum
+  ): String
+
+  """The unique resource identifier path"""
+  uri: String
+}
+
+"""
+A paginated collection of Sponsor Nodes, Supports cursor-based pagination and filtering to efficiently retrieve sets of Sponsor Nodes
+"""
+interface SponsorConnection implements Connection {
+  """
+  A list of edges (relational context) between RootQuery and connected Sponsor Nodes
+  """
+  edges: [SponsorConnectionEdge!]!
+
+  """A list of connected Sponsor Nodes"""
+  nodes: [Sponsor!]!
+
+  """Information about pagination in a connection."""
+  pageInfo: SponsorConnectionPageInfo!
+}
+
+"""
+Represents a connection to a Sponsor. Contains both the Sponsor Node and metadata about the relationship.
+"""
+interface SponsorConnectionEdge implements Edge {
+  """
+  Opaque reference to the nodes position in the connection. Value can be used with pagination args.
+  """
+  cursor: String
+
+  """The connected Sponsor Node"""
+  node: Sponsor!
+}
+
+"""
+Pagination metadata specific to &quot;SponsorConnectionEdge&quot; collections. Provides cursors and flags for navigating through sets of &quot;SponsorConnectionEdge&quot; Nodes.
+"""
+interface SponsorConnectionPageInfo implements PageInfo & WPPageInfo {
+  """When paginating forwards, the cursor to continue."""
+  endCursor: String
+
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+
+  """Raw schema for page"""
+  seo: SEOPostTypePageInfo
+
+  """When paginating backwards, the cursor to continue."""
+  startCursor: String
+}
+
+"""EditorBlock Interface for Sponsor Block Type"""
+interface SponsorEditorBlock implements EditorBlock {
+  """The API version of the Gutenberg Block"""
+  apiVersion: Int
+
+  """The name of the category the Block belongs to"""
+  blockEditorCategoryName: String
+
+  """The id of the Block"""
+  clientId: String
+
+  """CSS Classnames to apply to the block"""
+  cssClassNames: [String]
+
+  """The inner blocks of the Block"""
+  innerBlocks: [EditorBlock]
+
+  """Whether the block is Dynamic (server rendered)"""
+  isDynamic: Boolean!
+
+  """The name of the Block"""
+  name: String
+
+  """The parent id of the Block"""
+  parentClientId: String
+
+  """The rendered HTML for the block"""
+  renderedHtml: String
+
+  """The (GraphQL) type of the block"""
+  type: String
+}
+
+"""
+Identifier types for retrieving a specific Sponsor. Specifies which unique attribute is used to find an exact Sponsor.
+"""
+enum SponsorIdType {
+  """Identify a resource by the Database ID."""
+  DATABASE_ID
+
+  """Identify a resource by the (hashed) Global ID."""
+  ID
+
+  """
+  Identify a resource by the slug. Available to non-hierarchcial Types where the slug is a unique identifier.
+  """
+  SLUG
+
+  """Identify a resource by the URI."""
+  URI
+}
+
+"""Connection between the Sponsor type and the Sponsor type"""
+type SponsorToParentConnectionEdge implements Edge & OneToOneConnection & SponsorConnectionEdge {
+  """
+  Opaque reference to the nodes position in the connection. Value can be used with pagination args.
+  """
+  cursor: String
+
+  """The node of the connection, without the edges"""
+  node: Sponsor! @deprecated(reason: "This content type is not hierarchical and typically will not have a parent")
+}
+
+"""Connection between the Sponsor type and the Sponsor type"""
+type SponsorToPreviewConnectionEdge implements Edge & OneToOneConnection & SponsorConnectionEdge {
+  """
+  Opaque reference to the nodes position in the connection. Value can be used with pagination args.
+  """
+  cursor: String
+
+  """The node of the connection, without the edges"""
+  node: Sponsor!
+}
+
+"""Connection between the Sponsor type and the Sponsor type"""
+type SponsorToRevisionConnection implements Connection & SponsorConnection {
+  """Edges for the SponsorToRevisionConnection connection"""
+  edges: [SponsorToRevisionConnectionEdge!]!
+
+  """The nodes of the connection, without the edges"""
+  nodes: [Sponsor!]!
+
+  """Information about pagination in a connection."""
+  pageInfo: SponsorToRevisionConnectionPageInfo!
+}
+
+"""An edge in a connection"""
+type SponsorToRevisionConnectionEdge implements Edge & SponsorConnectionEdge {
+  """A cursor for use in pagination"""
+  cursor: String
+
+  """The item at the end of the edge"""
+  node: Sponsor!
+}
+
+"""
+Pagination metadata specific to &quot;SponsorToRevisionConnection&quot; collections. Provides cursors and flags for navigating through sets of SponsorToRevisionConnection Nodes.
+"""
+type SponsorToRevisionConnectionPageInfo implements PageInfo & SponsorConnectionPageInfo & WPPageInfo {
+  """When paginating forwards, the cursor to continue."""
+  endCursor: String
+
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+
+  """Raw schema for page"""
+  seo: SEOPostTypePageInfo
+
+  """When paginating backwards, the cursor to continue."""
+  startCursor: String
+}
+
+"""Arguments for filtering the SponsorToRevisionConnection connection"""
+input SponsorToRevisionConnectionWhereArgs {
+  """Filter the connection based on dates"""
+  dateQuery: DateQueryInput
+
+  """
+  True for objects with passwords; False for objects without passwords; null for all objects with or without passwords
+  """
+  hasPassword: Boolean
+
+  """Specific database ID of the object"""
+  id: Int
+
+  """Array of IDs for the objects to retrieve"""
+  in: [ID]
+
+  """Get objects with a specific mimeType property"""
+  mimeType: MimeTypeEnum
+
+  """Slug / post_name of the object"""
+  name: String
+
+  """Specify objects to retrieve. Use slugs"""
+  nameIn: [String]
+
+  """
+  Specify IDs NOT to retrieve. If this is used in the same query as "in", it will be ignored
+  """
+  notIn: [ID]
+
+  """What parameter to use to order the objects by."""
+  orderby: [PostObjectsConnectionOrderbyInput]
+
+  """Use ID to return only children. Use 0 to return only top-level items"""
+  parent: ID
+
+  """Specify objects whose parent is in an array"""
+  parentIn: [ID]
+
+  """Specify posts whose parent is not in an array"""
+  parentNotIn: [ID]
+
+  """Show posts with a specific password."""
+  password: String
+
+  """Show Posts based on a keyword search"""
+  search: String
+
+  """Retrieve posts where post status is in an array."""
+  stati: [PostStatusEnum]
+
+  """Show posts with a specific status."""
+  status: PostStatusEnum
+
+  """Title of the object"""
+  title: String
+}
+
+"""Connection between the Sponsor type and the Sponsor type"""
+type SponsorToSponsorConnection implements Connection & SponsorConnection {
+  """Edges for the SponsorToSponsorConnection connection"""
+  edges: [SponsorToSponsorConnectionEdge!]!
+
+  """The nodes of the connection, without the edges"""
+  nodes: [Sponsor!]!
+
+  """Information about pagination in a connection."""
+  pageInfo: SponsorToSponsorConnectionPageInfo!
+}
+
+"""An edge in a connection"""
+type SponsorToSponsorConnectionEdge implements Edge & SponsorConnectionEdge {
+  """A cursor for use in pagination"""
+  cursor: String @deprecated(reason: "This content type is not hierarchical and typically will not have ancestors")
+
+  """The item at the end of the edge"""
+  node: Sponsor! @deprecated(reason: "This content type is not hierarchical and typically will not have ancestors")
+}
+
+"""
+Pagination metadata specific to &quot;SponsorToSponsorConnection&quot; collections. Provides cursors and flags for navigating through sets of SponsorToSponsorConnection Nodes.
+"""
+type SponsorToSponsorConnectionPageInfo implements PageInfo & SponsorConnectionPageInfo & WPPageInfo {
+  """When paginating forwards, the cursor to continue."""
+  endCursor: String
+
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+
+  """Raw schema for page"""
+  seo: SEOPostTypePageInfo
+
+  """When paginating backwards, the cursor to continue."""
+  startCursor: String
 }
 
 """
@@ -27935,6 +28709,59 @@ type UpdateSettingsPayload {
   writingSettings: WritingSettings
 }
 
+"""Input for the updateSponsor mutation."""
+input UpdateSponsorInput {
+  """
+  This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions.
+  """
+  clientMutationId: String
+
+  """The content of the object"""
+  content: String
+
+  """
+  The date of the object. Preferable to enter as year/month/day (e.g. 01/31/2017) as it will rearrange date as fit if it is not specified. Incomplete dates may have unintended results for example, "2017" as the input will use current date with timestamp 20:17 
+  """
+  date: String
+
+  """The excerpt of the object"""
+  excerpt: String
+
+  """The ID of the Sponsor object"""
+  id: ID!
+
+  """Override the edit lock when another user is editing the post"""
+  ignoreEditLock: Boolean
+
+  """
+  A field used for ordering posts. This is typically used with nav menu items or for special ordering of hierarchical content types.
+  """
+  menuOrder: Int
+
+  """The password used to protect the content of the object"""
+  password: String
+
+  """The slug of the object"""
+  slug: String
+
+  """The status of the object"""
+  status: PostStatusEnum
+
+  """The title of the object"""
+  title: String
+}
+
+"""The payload for the updateSponsor mutation."""
+type UpdateSponsorPayload {
+  """
+  If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions.
+  """
+  clientMutationId: String
+
+  """The Post object mutation type."""
+  sponsor: Sponsor
+}
+
 """Input for the updateTag mutation."""
 input UpdateTagInput {
   """The slug that the post_tag will be an alias of"""
@@ -29361,7 +30188,7 @@ type WritingSettings {
 }
 
 """A block used for editing the site"""
-type YoastFaqBlock implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type YoastFaqBlock implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -29425,7 +30252,7 @@ type YoastFaqBlockAttributes {
 }
 
 """A block used for editing the site"""
-type YoastHowToBlock implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type YoastHowToBlock implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 
@@ -29534,7 +30361,7 @@ type YoastHowToBlockAttributes {
 }
 
 """A block used for editing the site"""
-type YoastSeoBreadcrumbs implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock {
+type YoastSeoBreadcrumbs implements EditorBlock & EventEditorBlock & PageEditorBlock & PostEditorBlock & SponsorEditorBlock {
   """The API version of the Gutenberg Block"""
   apiVersion: Int
 


### PR DESCRIPTION
Closes #246.

## Summary

Parses the downloaded `schema.graphql` at build time and emits a base fragment plus standard list / `ByUri` / `BySlug` queries for every CPT that implements `ContentNode`. Built-in types (`Post`, `Page`, `MediaItem`, `Revision`, `Comment`, `ActionMonitorAction`) are excluded because they already have default queries.

For each discovered CPT the generator writes:
- `.queries/fragments/${Type}.fragment.gql` — spreads `...ContentNode` plus `...NodeWithExcerpt` / `...NodeWithContentEditor` / `...NodeWithFeaturedImage` **only when the type actually implements the matching interface**. A CPT registered without excerpt support will not get an `excerpt` field in its fragment.
- `.queries/${Plural}.gql` — named after the connection field (`events` → `Events.gql`) to mirror the built-in `Posts.gql` convention. Contains a cursor-based connection query plus `ByUri` / `BySlug` single-fetch queries, **each emitted only when the idType enum contains that value**.

CPT type names are also injected into `NodeByUri` as inline fragment spreads so the polymorphic `nodeByUri` query stays consistent with the list queries. The existing `addCustomFragmentsToNodeQuery` logic was extended to accept the generator's output and merged with user-declared content-type fragments (dedup by type).

## Override mechanism

Generated files land in `.queries/` **before** `extend/queries/` is copied over. Dropping a file with the same name in `extend/queries/fragments/` (for fragments) or `extend/queries/` (for queries) replaces the generated one entirely — same semantics as overriding a default query today. No extension / delta-merge in this pass; that can come later if people want it.

## Config

```ts
wpNuxt: {
  cpt: {
    enabled: true,      // default
    exclude: ['Draft'], // skip specific types in addition to built-ins
    include: ['Event']  // if set, ONLY these types get generated
  }
}
```

## Schema timing

`mergeQueries()` now runs **after** the schema-download block in `module.ts` so CPT discovery has `schema.graphql` to parse on the very first build. When the schema is missing or malformed (disconnected cold build), `discoverCpts()` returns `[]` — CPT generation silently no-ops, defaults still get merged, module setup does not fail.

## Public API impact

Additive. `mergeQueries` gains an optional `schemaPath` parameter (callers can omit). No user-visible behaviour change for projects without CPTs; users with manually-written CPT fragments see their files win the merge (verified in `playgrounds/full` — user's ACF-extended `Event.fragment.gql` was not overwritten).

## Test plan

- [x] `pnpm run check` passes locally — 275/275 core tests (20 new across `cptDiscovery.test.ts` and `generateCpt.test.ts`), all 4 playgrounds build clean.
- [x] `cptDiscovery.test.ts`: schema-missing / malformed-schema / ContentNode filtering / `exclude` & `include` options / interface & idType extraction / skipping types without both single+connection RootQuery fields.
- [x] `generateCpt.test.ts`: fragment spread conditionality / `ByUri` & `BySlug` conditionality based on idType enum / file-level override behaviour (won't clobber existing files).
- [x] End-to-end verification on `playgrounds/blocks` (no user Event overrides): generator produced clean `Events.gql` + `Event.fragment.gql`, `Node.gql` got `... on Event { ...Event }` spread.
- [x] End-to-end verification on `playgrounds/full` (user has `extend/queries/Events.gql` and `extend/queries/fragments/Event.fragment.gql` with ACF fields): both user files won the merge unchanged.
- [ ] Smoke test in `pnpm run dev:blocks` — navigate and confirm `useEvents()` / `useEventByUri()` / `useEventBySlug()` resolve against the WordPress instance.