### PR TITLE
fix(core): import useRoute from vue-router in clientOptions

### DIFF
--- a/packages/core/app/graphqlMiddleware.clientOptions.ts
+++ b/packages/core/app/graphqlMiddleware.clientOptions.ts
@@ -1,5 +1,5 @@
 import { defineGraphqlClientOptions } from 'nuxt-graphql-middleware/client-options'
-import { useRoute } from '#imports'
+import { useRoute } from 'vue-router'
 
 /**
  * WPNuxt default client options for nuxt-graphql-middleware.


### PR DESCRIPTION
## Summary
- `packages/core/app/graphqlMiddleware.clientOptions.ts` was importing `useRoute` from `#imports`, but `nuxt-graphql-middleware`'s client-options loader runs outside Nuxt's module transform pipeline, so the virtual alias doesn't resolve
- Downstream projects had to carry `pnpm patch` / `patch-package` workarounds to build
- Switch to importing directly from `vue-router` — it resolves in any loader context and is already a Nuxt runtime dep, so no new dependency and no behavioral change

Closes #269

## Test plan
- [x] `pnpm run check` (dev:prepare → lint → typecheck → test → build) passes locally
- [ ] Verify in a downstream project that removing the patch-package workaround still builds