### PR TITLE
fix(core): distinguish introspection-disabled from outdated WPGraphQL

### DIFF
--- a/packages/core/src/utils/endpointValidation.ts
+++ b/packages/core/src/utils/endpointValidation.ts
@@ -205,7 +205,33 @@ async function checkWPGraphQLVersion(
     if (!response.ok) return // Skip check if request fails — endpoint validation already handles this
 
     const data = await response.json()
-    const fields: Array<{ name: string }> = data?.data?.__type?.fields || []
+
+    // Detect "Public Introspection disabled" responses from WPGraphQL so we
+    // don't misreport them as an outdated plugin version.
+    const errorMessage: string = data?.errors?.[0]?.message || ''
+    if (/introspection/i.test(errorMessage)) {
+      throw new Error(
+        `[wpnuxt:core] WPGraphQL Public Introspection is disabled on this endpoint.
+
+URL: ${fullUrl}
+
+WPNuxt needs introspection to validate the schema and generate types.
+
+To fix:
+- Enable "Enable Public Introspection" under WPGraphQL → Settings in the WordPress admin.
+- Or provide authenticated credentials that are permitted to introspect the schema.
+
+WPGraphQL error: ${errorMessage}`
+      )
+    }
+
+    // If __type is missing without an introspection error, we can't reliably
+    // tell whether the plugin is outdated or introspection is otherwise
+    // blocked — skip rather than surface a misleading "too old" message.
+    const type = data?.data?.__type
+    if (!type) return
+
+    const fields: Array<{ name: string }> = type.fields || []
     const hasFilePath = fields.some(f => f.name === 'filePath')
 
     if (!hasFilePath) {


### PR DESCRIPTION
## Summary
- WPGraphQL's *Enable Public Introspection* setting is disabled by default. When off, the `__type(name: "MediaDetails")` probe used to detect WPGraphQL >= 2.0.0 comes back as an error rather than a field list — which `checkWPGraphQLVersion` previously misreported as *"WPGraphQL version is too old"*, even on current WPGraphQL versions
- Detect introspection-disabled responses from `data.errors` and throw a specific, actionable error pointing users at **WPGraphQL → Settings → Enable Public Introspection** (or suggesting authenticated credentials), and include the original WPGraphQL error message
- Don't conclude "too old" unless `__type` actually returned a field list without `filePath` — otherwise return and let the downstream schema-download step surface its own error rather than mislead

Closes #260

## Test plan
- [x] `pnpm run check` (dev:prepare → lint → typecheck → test → build) passes locally
- [ ] Manual: point a project at a WPGraphQL endpoint with Public Introspection disabled, confirm the new error message appears instead of the misleading "version too old" one
- [ ] Manual: confirm an actually-outdated WPGraphQL install still triggers the "too old" path