### PR TITLE
fix: add wpnuxt:queries:folders hook so modules stop hardcoding the merged queries path

### DIFF
--- a/docs/content/5.reference/1.configuration.md
+++ b/docs/content/5.reference/1.configuration.md
@@ -216,6 +216,31 @@ wpNuxtAuth: {
 }
 ```
 
+## Hooks
+
+### `wpnuxt:queries:folders`
+
+For Nuxt module authors: contribute additional GraphQL query folders to WPNuxt's merged queries (this is how `@wpnuxt/blocks` adds its block fragments).
+
+`@wpnuxt/core` calls this hook at `modules:done`, so you can register it during your module's `setup()` regardless of module order in `nuxt.config.ts`. Push absolute folder paths; `.gql`/`.graphql` files are copied recursively into the merged output folder.
+
+```ts [my-module.ts]
+export default defineNuxtModule({
+  setup(options, nuxt) {
+    const { resolve } = createResolver(import.meta.url)
+    nuxt.hook('wpnuxt:queries:folders', (folders) => {
+      folders.push(resolve('./runtime/queries'))
+    })
+  }
+})
+```
+
+Merge precedence (later wins): core defaults → CPT auto-generation → contributed folders → user `extend/queries/`. A contributed `Post.fragment.gql` overrides the default fragment, while users can still override contributed fragments from their `extend/queries/` folder.
+
+::note
+Contributed folders are intended for **fragments**. Contributed queries are passed to nuxt-graphql-middleware, but they do not get generated `use*()` composables.
+::
+
 ## Environment Variables
 
 ### @wpnuxt/core

--- a/packages/auth/src/module.ts
+++ b/packages/auth/src/module.ts
@@ -1,17 +1,17 @@
-import { existsSync, cpSync } from 'node:fs'
 import { join } from 'node:path'
 import { defineNuxtModule, addPlugin, createResolver, addImports, addServerHandler, useLogger } from '@nuxt/kit'
 import type { WPNuxtAuthConfig } from './runtime/types'
 import { validateAuthSchema } from './utils/schemaDetection'
 
-/**
- * Helper type for accessing WPNuxt config from Nuxt options.
- * This is needed because @wpnuxt/auth may be installed without @wpnuxt/core types.
- */
-interface WPNuxtQueriesConfig {
-  queries?: {
-    mergedOutputFolder?: string
-    extendFolder?: string
+declare module '@nuxt/schema' {
+  interface NuxtHooks {
+    /**
+     * Contribute additional GraphQL query folders to WPNuxt's merged queries.
+     * Declared here because @wpnuxt/core's type augmentation isn't importable
+     * (its exports map only exposes dist/). Must stay in sync with
+     * packages/core/src/types/nuxt-augment.d.ts.
+     */
+    'wpnuxt:queries:folders': (folders: string[]) => void | Promise<void>
   }
 }
 
@@ -63,23 +63,14 @@ export default defineNuxtModule<WPNuxtAuthConfig>({
 
     const resolver = createResolver(import.meta.url)
 
-    // Extend queries with auth-specific fragments
-    const baseDir = nuxt.options.srcDir || nuxt.options.rootDir
-    const { resolve } = createResolver(baseDir)
-    const wpNuxtConfig = (nuxt.options as { wpNuxt?: WPNuxtQueriesConfig }).wpNuxt
-    const mergedQueriesPath = resolve(wpNuxtConfig?.queries?.mergedOutputFolder || '.queries/')
-    const userQueryPath = resolve(wpNuxtConfig?.queries?.extendFolder || 'extend/queries/')
-    const authQueriesPath = resolver.resolve('./runtime/queries')
-
-    // Copy auth queries (overrides core defaults)
-    if (existsSync(authQueriesPath)) {
-      cpSync(authQueriesPath, mergedQueriesPath, { recursive: true })
-    }
-
-    // Re-copy user queries to ensure they still override auth
-    if (existsSync(userQueryPath)) {
-      cpSync(userQueryPath, mergedQueriesPath, { recursive: true })
-    }
+    // Contribute auth queries (Login/RefreshToken mutations, Viewer override)
+    // to @wpnuxt/core's merged queries folder. Core collects these at
+    // modules:done and merges them into its configured mergedOutputFolder
+    // with the right precedence (defaults < contributions < user extends),
+    // so module order doesn't matter and custom output folders are respected.
+    nuxt.hook('wpnuxt:queries:folders', (folders) => {
+      folders.push(resolver.resolve('./runtime/queries'))
+    })
 
     // Merge OAuth config with defaults
     const oauthConfig = {

--- a/packages/blocks/src/module.ts
+++ b/packages/blocks/src/module.ts
@@ -1,8 +1,19 @@
-import { promises as fsp, existsSync, cpSync } from 'node:fs'
-import { join } from 'node:path'
+import { promises as fsp } from 'node:fs'
 import { defineNuxtModule, installModule, createResolver, addComponentsDir, addTemplate, hasNuxtModule, useLogger } from '@nuxt/kit'
 
 const logger = useLogger('@wpnuxt/blocks')
+
+declare module '@nuxt/schema' {
+  interface NuxtHooks {
+    /**
+     * Contribute additional GraphQL query folders to WPNuxt's merged queries.
+     * Declared here because @wpnuxt/core's type augmentation isn't importable
+     * (its exports map only exposes dist/). Must stay in sync with
+     * packages/core/src/types/nuxt-augment.d.ts.
+     */
+    'wpnuxt:queries:folders': (folders: string[]) => void | Promise<void>
+  }
+}
 
 export interface WPNuxtBlocksConfig {
   /**
@@ -108,15 +119,14 @@ export default defineNuxtModule<WPNuxtBlocksConfig>({
       }
     }
 
-    // Copy block queries to the merged queries folder
-    // @wpnuxt/core creates .queries in srcDir (which is 'app/' in Nuxt 4)
-    const blocksQueriesPath = resolveRuntimeModule('./queries')
-    const mergedQueriesFolder = join(nuxt.options.srcDir, '.queries')
-
-    // Copy block queries synchronously to ensure they're available
-    if (existsSync(mergedQueriesFolder) && existsSync(blocksQueriesPath)) {
-      cpSync(blocksQueriesPath, mergedQueriesFolder, { recursive: true })
-    }
+    // Contribute block fragments to @wpnuxt/core's merged queries folder.
+    // Core collects these at modules:done and merges them into its configured
+    // mergedOutputFolder, so module order doesn't matter and custom output
+    // folders are respected. If core isn't installed the hook is never
+    // called — graceful no-op.
+    nuxt.hook('wpnuxt:queries:folders', (folders) => {
+      folders.push(resolveRuntimeModule('./queries'))
+    })
 
     // Register module block components
     addComponentsDir({

--- a/packages/core/src/module.ts
+++ b/packages/core/src/module.ts
@@ -134,6 +134,22 @@ export default defineNuxtModule<WPNuxtConfig>({
 
     const mergedQueriesFolder = await mergeQueries(nuxt, wpNuxtConfig, resolver, schemaPath)
 
+    // Collect query folders contributed by sibling modules (e.g. @wpnuxt/blocks)
+    // via the `wpnuxt:queries:folders` hook. Collected at modules:done so it
+    // works regardless of module order in nuxt.config. Registered BEFORE
+    // registerModules() so this handler runs before nuxt-graphql-middleware's
+    // own modules:done handler scans the merged folder.
+    nuxt.hook('modules:done', async () => {
+      const contributedFolders: string[] = []
+      await nuxt.callHook('wpnuxt:queries:folders', contributedFolders)
+      if (contributedFolders.length) {
+        logger.debug(`Re-merging queries with ${contributedFolders.length} contributed folder(s)`)
+        // Suppress the override warning: the setup-time merge already emitted it
+        const remergeConfig = { ...wpNuxtConfig, queries: { ...wpNuxtConfig.queries, warnOnOverride: false } }
+        await mergeQueries(nuxt, remergeConfig, resolver, schemaPath, contributedFolders)
+      }
+    })
+
     await registerModules(nuxt, resolver, wpNuxtConfig, mergedQueriesFolder)
 
     // Customize the nuxt-graphql-middleware devtools tab for WPNuxt branding

--- a/packages/core/src/types/nuxt-augment.d.ts
+++ b/packages/core/src/types/nuxt-augment.d.ts
@@ -59,6 +59,32 @@ declare module '@nuxt/schema' {
       status: 'success' | 'error'
       error?: Error
     }) => void | Promise<void>
+    /**
+     * Contribute additional GraphQL query folders to WPNuxt's merged queries.
+     *
+     * Called by @wpnuxt/core at `modules:done`, so modules can register this
+     * hook during their own setup regardless of module order in nuxt.config.
+     * Push absolute folder paths; `.gql`/`.graphql` files are copied
+     * recursively into the merged output folder.
+     *
+     * Precedence: core defaults < CPT auto-generation < contributed folders
+     * < user `extend/queries/`. Same-named files override earlier ones, so a
+     * contributed `Post.fragment.gql` replaces the default, while users can
+     * still override contributed fragments.
+     *
+     * Note: contributed folders are intended for fragments. Contributed
+     * queries are sent to nuxt-graphql-middleware but do NOT get generated
+     * `use*()` composables (composable generation runs before this hook).
+     *
+     * @example
+     * ```ts
+     * // in a sibling module's setup()
+     * nuxt.hook('wpnuxt:queries:folders', (folders) => {
+     *   folders.push(resolve('./runtime/queries'))
+     * })
+     * ```
+     */
+    'wpnuxt:queries:folders': (folders: string[]) => void | Promise<void>
   }
 }
 

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -83,7 +83,8 @@ export async function mergeQueries(
   nuxt: Nuxt,
   wpNuxtConfig: WPNuxtConfig,
   resolver: Resolver,
-  schemaPath?: string
+  schemaPath?: string,
+  contributedFolders: string[] = []
 ) {
   const logger = getLogger()
 
@@ -115,6 +116,17 @@ export async function mergeQueries(
     }
     if (cpts.length) {
       logger.debug(`Auto-generated fragments + queries for CPTs: ${cpts.map(c => c.typeName).join(', ')}`)
+    }
+  }
+
+  // Apply query folders contributed by sibling modules (e.g. @wpnuxt/blocks)
+  // via the `wpnuxt:queries:folders` hook. Applied after defaults + CPT
+  // generation but BEFORE user extend queries, so users can still override
+  // any contributed fragment.
+  for (const folder of contributedFolders) {
+    if (existsSync(folder)) {
+      logger.debug('Merging contributed queries:', folder)
+      copyGraphqlFiles(folder, queryOutputPath)
     }
   }
 

--- a/packages/core/test/mergeQueries.test.ts
+++ b/packages/core/test/mergeQueries.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from 'vitest'
+import { mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { createResolver } from '@nuxt/kit'
+import type { Nuxt } from 'nuxt/schema'
+import type { WPNuxtConfig } from '../src/types/config'
+import { mergeQueries, initLogger } from '../src/utils/index'
+
+const TEST_DIR = join(__dirname, '.tmp-merge-queries')
+const SRC_DIR = join(TEST_DIR, 'app')
+const PACKAGE_DIR = join(TEST_DIR, 'package')
+const DEFAULTS_DIR = join(PACKAGE_DIR, 'runtime', 'queries')
+const CONTRIB_DIR = join(TEST_DIR, 'contrib')
+const USER_DIR = join(SRC_DIR, 'extend', 'queries')
+const OUTPUT_DIR = join(SRC_DIR, '.queries')
+
+const DEFAULT_POST_FRAGMENT = 'fragment Post on Post {\n  title\n}\n'
+const CONTRIB_POST_FRAGMENT = 'fragment Post on Post {\n  title\n  ...NodeWithEditorBlocks\n}\n'
+const USER_POST_FRAGMENT = 'fragment Post on Post {\n  title\n  userCustomField\n}\n'
+
+const nuxt = { options: { srcDir: SRC_DIR, rootDir: TEST_DIR } } as Nuxt
+
+const config = {
+  queries: {
+    extendFolder: 'extend/queries/',
+    mergedOutputFolder: '.queries/',
+    warnOnOverride: false
+  },
+  cpt: { enabled: false }
+} as WPNuxtConfig
+
+function readOutput(relativePath: string): string {
+  return readFileSync(join(OUTPUT_DIR, relativePath), 'utf-8')
+}
+
+function runMergeQueries(contributedFolders: string[] = []) {
+  return mergeQueries(nuxt, config, createResolver(PACKAGE_DIR), undefined, contributedFolders)
+}
+
+describe('mergeQueries', () => {
+  beforeAll(() => {
+    initLogger(false)
+  })
+
+  beforeEach(() => {
+    mkdirSync(join(DEFAULTS_DIR, 'fragments'), { recursive: true })
+    writeFileSync(join(DEFAULTS_DIR, 'Posts.gql'), 'query Posts {\n  posts {\n    nodes {\n      ...Post\n    }\n  }\n}\n')
+    writeFileSync(join(DEFAULTS_DIR, 'fragments', 'Post.fragment.gql'), DEFAULT_POST_FRAGMENT)
+    mkdirSync(SRC_DIR, { recursive: true })
+  })
+
+  afterEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true })
+  })
+
+  it('copies default queries to the output folder', async () => {
+    const output = await runMergeQueries()
+
+    expect(output).toBe(OUTPUT_DIR)
+    expect(readOutput('Posts.gql')).toContain('query Posts')
+    expect(readOutput('fragments/Post.fragment.gql')).toBe(DEFAULT_POST_FRAGMENT)
+  })
+
+  it('copies contributed folders into the output folder', async () => {
+    mkdirSync(join(CONTRIB_DIR, 'fragments'), { recursive: true })
+    writeFileSync(join(CONTRIB_DIR, 'fragments', 'EditorBlock.fragment.gql'), 'fragment EditorBlock on EditorBlock {\n  name\n}\n')
+
+    await runMergeQueries([CONTRIB_DIR])
+
+    expect(readOutput('fragments/EditorBlock.fragment.gql')).toContain('fragment EditorBlock')
+  })
+
+  it('lets contributed fragments override default fragments', async () => {
+    mkdirSync(join(CONTRIB_DIR, 'fragments'), { recursive: true })
+    writeFileSync(join(CONTRIB_DIR, 'fragments', 'Post.fragment.gql'), CONTRIB_POST_FRAGMENT)
+
+    await runMergeQueries([CONTRIB_DIR])
+
+    expect(readOutput('fragments/Post.fragment.gql')).toBe(CONTRIB_POST_FRAGMENT)
+  })
+
+  it('lets user extend queries override contributed fragments', async () => {
+    mkdirSync(join(CONTRIB_DIR, 'fragments'), { recursive: true })
+    writeFileSync(join(CONTRIB_DIR, 'fragments', 'Post.fragment.gql'), CONTRIB_POST_FRAGMENT)
+    mkdirSync(join(USER_DIR, 'fragments'), { recursive: true })
+    writeFileSync(join(USER_DIR, 'fragments', 'Post.fragment.gql'), USER_POST_FRAGMENT)
+
+    await runMergeQueries([CONTRIB_DIR])
+
+    expect(readOutput('fragments/Post.fragment.gql')).toBe(USER_POST_FRAGMENT)
+  })
+
+  it('only copies .gql and .graphql files from contributed folders', async () => {
+    mkdirSync(join(CONTRIB_DIR, 'fragments'), { recursive: true })
+    writeFileSync(join(CONTRIB_DIR, 'README.md'), '# Not a query\n')
+    writeFileSync(join(CONTRIB_DIR, 'fragments', 'EditorBlock.fragment.gql'), 'fragment EditorBlock on EditorBlock {\n  name\n}\n')
+
+    await runMergeQueries([CONTRIB_DIR])
+
+    expect(existsSync(join(OUTPUT_DIR, 'README.md'))).toBe(false)
+    expect(existsSync(join(OUTPUT_DIR, 'fragments', 'EditorBlock.fragment.gql'))).toBe(true)
+  })
+
+  it('skips contributed folders that do not exist', async () => {
+    await runMergeQueries([join(TEST_DIR, 'does-not-exist')])
+
+    expect(readOutput('fragments/Post.fragment.gql')).toBe(DEFAULT_POST_FRAGMENT)
+  })
+})


### PR DESCRIPTION
Fixes #278

### Problem

@wpnuxt/blocks copied its Gutenberg fragments into core's merged queries folder by guessing its location (join(srcDir, '.queries')). With a custom queries.mergedOutputFolder, core writes elsewhere, the guess misses, and block fragments are silently dropped — BlockRenderer queries lose editorBlocks with zero feedback.
@wpnuxt/auth had the same pattern (reading raw unresolved config + duplicating the default), plus its own "re-copy user queries" workaround. Both also silently required being listed after @wpnuxt/core in nuxt.config.ts.

Note #278's diff targets the wrong file — core already resolved mergedOutputFolder correctly; the hardcoding was in blocks (and auth). Rather than re-deriving the path in each module, this removes the coupling entirely.

### Solution

A new wpnuxt:queries:folders hook. Modules push their query folder paths during setup; core collects them at modules:done (registered before nuxt-graphql-middleware is installed, so the re-merge lands before it scans documents) and merges everything with explicit precedence:

core defaults < CPT auto-generation < contributed folders < user extend/queries/

- @wpnuxt/blocks and @wpnuxt/auth: path-guessing copy blocks replaced by 3-line hook registrations
- Hook typed + documented in nuxt-augment.d.ts and the configuration reference docs
- New unit tests for contribution copy, override precedence, .gql-only filtering

### Behavior changes

- Bug fix (#278): contributed fragments follow the configured mergedOutputFolder
- Bug fix: user extend/queries/ now overrides blocks fragments (blocks previously clobbered user files)
- Improvement: module order in nuxt.config.ts no longer matters
- Known limitation (documented): contributed queries don't get generated use*() composables — same as before (auth's LoginClients/Viewer never had them)

### Verification

- pnpm run check passes: lint, typecheck (7 projects), 379 tests, all playground builds
- Blocks playground with mergedOutputFolder: '.custom-queries/': fragments land in the custom folder (previously dropped)
- Blocks playground with @wpnuxt/blocks listed before @wpnuxt/core: works
- Full playground dev run: both auth + blocks contribute, all GraphQL documents valid