### PR TITLE
fix(ci): retry playwright install to survive transient apt-mirror failures

### DIFF
--- a/.github/actions/setup-wp-e2e/action.yml
+++ b/.github/actions/setup-wp-e2e/action.yml
@@ -109,7 +109,13 @@ runs:
     - name: Install Playwright browsers
       working-directory: e2e
       shell: bash
-      run: pnpm exec playwright install --with-deps
+      run: |
+        for i in 1 2 3; do
+          pnpm exec playwright install --with-deps && break
+          if [ "$i" = "3" ]; then echo "playwright install failed after 3 attempts"; exit 1; fi
+          echo "playwright install failed (attempt $i), retrying in 15s..."
+          sleep 15
+        done
 
     - name: Run E2E tests
       shell: bash


### PR DESCRIPTION
## Summary
- `playwright install --with-deps` was failing intermittently in CI due to transient apt-mirror errors (e.g. corrupt package metadata from packages.microsoft.com), unrelated to any code change
- Wraps the install in a 3-attempt retry loop with a 15s backoff between attempts, exiting non-zero only if all 3 attempts fail
- Shared composite action, so this covers both the `ci.yml` E2E job and the `compatibility.yml` matrix

Fixes #286

## Test plan
- [x] `pnpm run check` passes (dev:prepare, lint, typecheck, test, build)
- [ ] Next CI run on this PR completes the E2E job successfully