### PR TITLE
feat(core): add default queries for search, categories, tags, and terms

### DIFF
--- a/docs/content/5.reference/2.composables.md
+++ b/docs/content/5.reference/2.composables.md
@@ -113,6 +113,17 @@ usePosts(undefined, { timeout: 10000 })
 | `useViewer()` | — |
 | `useRevisions()` | `{ id: string }` |
 
+### Taxonomy & Search
+
+These are [connection queries](#connection-queries-pagination) — they return `data`, `pageInfo`, and `loadMore()`.
+
+| Composable | Variables |
+|------------|-----------|
+| `useSearch()` | `{ term: string, first?: number, after?: string }` |
+| `useCategories()` | `{ first?: number, after?: string, where?: RootQueryToCategoryConnectionWhereArgs }` |
+| `useTags()` | `{ first?: number, after?: string, where?: RootQueryToTagConnectionWhereArgs }` |
+| `useTerms()` | `{ taxonomies?: TaxonomyEnum[], first?: number, after?: string }` |
+
 ### Navigation
 
 | Composable | Description |

--- a/packages/core/src/runtime/queries/Categories.gql
+++ b/packages/core/src/runtime/queries/Categories.gql
@@ -1,0 +1,13 @@
+query Categories($first: Int = 100, $after: String, $where: RootQueryToCategoryConnectionWhereArgs) {
+  categories(first: $first, after: $after, where: $where) {
+    pageInfo {
+      hasNextPage
+      hasPreviousPage
+      endCursor
+      startCursor
+    }
+    nodes {
+      ...Category
+    }
+  }
+}

--- a/packages/core/src/runtime/queries/Search.gql
+++ b/packages/core/src/runtime/queries/Search.gql
@@ -1,0 +1,19 @@
+query Search($term: String!, $first: Int = 10, $after: String) {
+  contentNodes(first: $first, after: $after, where: { search: $term }) {
+    pageInfo {
+      hasNextPage
+      hasPreviousPage
+      endCursor
+      startCursor
+    }
+    nodes {
+      ...ContentNode
+      ... on NodeWithTitle {
+        title
+      }
+      ... on NodeWithExcerpt {
+        ...NodeWithExcerpt
+      }
+    }
+  }
+}

--- a/packages/core/src/runtime/queries/Tags.gql
+++ b/packages/core/src/runtime/queries/Tags.gql
@@ -1,0 +1,13 @@
+query Tags($first: Int = 100, $after: String, $where: RootQueryToTagConnectionWhereArgs) {
+  tags(first: $first, after: $after, where: $where) {
+    pageInfo {
+      hasNextPage
+      hasPreviousPage
+      endCursor
+      startCursor
+    }
+    nodes {
+      ...Tag
+    }
+  }
+}

--- a/packages/core/src/runtime/queries/Terms.gql
+++ b/packages/core/src/runtime/queries/Terms.gql
@@ -1,0 +1,13 @@
+query Terms($taxonomies: [TaxonomyEnum], $first: Int = 100, $after: String) {
+  terms(first: $first, after: $after, where: { taxonomies: $taxonomies }) {
+    pageInfo {
+      hasNextPage
+      hasPreviousPage
+      endCursor
+      startCursor
+    }
+    nodes {
+      ...TermNode
+    }
+  }
+}

--- a/packages/core/src/runtime/queries/fragments/Category.fragment.gql
+++ b/packages/core/src/runtime/queries/fragments/Category.fragment.gql
@@ -1,0 +1,11 @@
+fragment Category on Category {
+  id
+  databaseId
+  name
+  slug
+  uri
+  description
+  count
+  parentId
+  parentDatabaseId
+}

--- a/packages/core/src/runtime/queries/fragments/Tag.fragment.gql
+++ b/packages/core/src/runtime/queries/fragments/Tag.fragment.gql
@@ -1,0 +1,9 @@
+fragment Tag on Tag {
+  id
+  databaseId
+  name
+  slug
+  uri
+  description
+  count
+}

--- a/packages/core/src/runtime/queries/fragments/TermNode.fragment.gql
+++ b/packages/core/src/runtime/queries/fragments/TermNode.fragment.gql
@@ -1,0 +1,10 @@
+fragment TermNode on TermNode {
+  id
+  databaseId
+  name
+  slug
+  uri
+  description
+  count
+  taxonomyName
+}

--- a/packages/core/src/runtime/util/content-type.ts
+++ b/packages/core/src/runtime/util/content-type.ts
@@ -1,5 +1,5 @@
 interface ContentNode {
-  contentTypeName: string
+  contentTypeName?: string
   [key: string]: unknown
 }
 

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -112,7 +112,13 @@ export async function mergeQueries(
   // Auto-generate fragments + queries for Custom Post Types discovered in
   // the downloaded schema. Runs BEFORE the user override copy so users can
   // still override any generated file by dropping one in extend/queries/.
-  const cptSpreads: ContentTypeFragment[] = []
+  // Category/Tag are seeded here too: they implement Node like CPTs do, so
+  // their fragments hit the same "Fragment X is never used" bundling issue
+  // unless spread into NodeByUri (see addCustomFragmentsToNodeQuery).
+  const cptSpreads: ContentTypeFragment[] = [
+    { name: 'Category', type: 'Category' },
+    { name: 'Tag', type: 'Tag' }
+  ]
   if (schemaPath && wpNuxtConfig.cpt?.enabled !== false) {
     const cpts = discoverCpts(schemaPath, {
       exclude: wpNuxtConfig.cpt?.exclude,

--- a/playgrounds/core/app/pages/[...slug].vue
+++ b/playgrounds/core/app/pages/[...slug].vue
@@ -13,7 +13,7 @@ const { data: node, pending } = await useNodeByUri(
       Fetching data for {{ $route.path }}...
     </p>
     <div v-else-if="node">
-      <h1>{{ node.title }}</h1>
+      <h1>{{ ('title' in node ? node.title : undefined) ?? ('name' in node ? node.name : undefined) }}</h1>
       <WPContent :node="node" />
     </div>
   </div>

--- a/playgrounds/full/app/pages/[...slug].vue
+++ b/playgrounds/full/app/pages/[...slug].vue
@@ -1,10 +1,14 @@
 <script setup lang="ts">
 const route = useRoute()
 
-const { data: post, pending, refresh, clear } = await useNodeByUri(
+const { data: node, pending, refresh, clear } = await useNodeByUri(
   { uri: route.path },
   { watch: [() => route.path] }
 )
+
+// nodeByUri can also resolve to a Category/Tag archive, which this page
+// doesn't render — narrow to content types (Page/Post/CPTs) only.
+const post = computed(() => (node.value && 'contentTypeName' in node.value) ? node.value : undefined)
 
 // Fetch all posts once for prev/next navigation (cached)
 const { data: allPosts } = await usePosts({ limit: 100 })

--- a/playgrounds/ssg/app/pages/[...uri].vue
+++ b/playgrounds/ssg/app/pages/[...uri].vue
@@ -4,6 +4,14 @@ const route = useRoute()
 const uri = route.path.endsWith('/') ? route.path : `${route.path}/`
 
 const { data: node } = await useNodeByUri({ uri })
+
+// nodeByUri can also resolve to a Category/Tag archive, which has `name`
+// instead of `title` and no `content` field.
+const title = computed(() => {
+  if (!node.value) return undefined
+  return 'title' in node.value ? node.value.title : ('name' in node.value ? node.value.name : undefined)
+})
+const content = computed(() => (node.value && 'content' in node.value) ? node.value.content : undefined)
 </script>
 
 <template>
@@ -17,10 +25,10 @@ const { data: node } = await useNodeByUri({ uri })
     >
       Back
     </UButton>
-    <UPageHeader :title="node.title" />
+    <UPageHeader :title="title" />
     <div
-      v-if="node.content"
-      v-sanitize-html="node.content"
+      v-if="content"
+      v-sanitize-html="content"
       class="prose prose-lg dark:prose-invert max-w-none"
     />
   </article>


### PR DESCRIPTION
Fixes #240

## Summary
- Adds `useSearch()`, `useCategories()`, `useTags()`, and `useTerms()` as default connection-query composables (search, `loadMore()`, pagination) so consumers get taxonomy browsing and site search out of the box.
- Category and Tag implement WPGraphQL's `Node` interface like CPTs do, so their fragments now get auto-spread into `NodeByUri` (same mechanism used for CPTs) — otherwise the server rejects the query with `Fragment "Category" is never used.` once nuxt-graphql-middleware bundles all `Node`-implementing fragments into the operation.
- Widening the `NodeByUri` union to include Category/Tag broke type guards (`isPage`/`isPost`/`isContentType`) and a few playground pages that assumed every node had `contentTypeName`/`title`. Relaxed the `ContentNode` guard constraint and narrowed the affected playground pages (`core`, `full`, `ssg`) accordingly.
- Docs updated with the new composables under "Taxonomy & Search".

## Test plan
- [x] `pnpm run check` green across all packages/playgrounds (dev:prepare → lint → typecheck → test → build)
- [x] Dev-tested in `playgrounds/full` — confirmed the "Fragment X is never used" error is gone and pages render correctly